### PR TITLE
ci: add skill validation CI check

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,3 +23,10 @@ jobs:
       - uses: actions/checkout@v4
       - name: Check For Large Files (under 50KB)
         run: bash ./scripts/check_large_files.sh
+  skill-validation:
+    name: 📋 Skill Validation
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Validate SKILL.md Files
+        run: bash ./scripts/validate_skills.sh

--- a/scripts/validate_skills.sh
+++ b/scripts/validate_skills.sh
@@ -1,0 +1,102 @@
+#!/bin/bash
+# Validates that every skills/*/SKILL.md follows the required structure:
+#   1. YAML frontmatter delimiters (opening and closing ---)
+#   2. name field present and matching ^[a-z0-9-]+$
+#   3. name matches the parent directory name
+#   4. description field present and non-empty
+#   5. H1 heading after frontmatter
+#   6. "## Standards (Non-Negotiable)" section exists
+
+errors=0
+
+while IFS= read -r file; do
+  file_errors=0
+  dir_name=$(basename "$(dirname "$file")")
+
+  # --- Check 1: Frontmatter opening ---
+  line1=$(sed -n '1p' "$file")
+  if [[ "$line1" != "---" ]]; then
+    echo "::error file=$file,line=1::Missing frontmatter opening delimiter (expected '---' on line 1)"
+    errors=$((errors + 1))
+    file_errors=$((file_errors + 1))
+  fi
+
+  # --- Check 2: Frontmatter closing ---
+  closing_line=$(awk 'NR > 1 && /^---$/ { print NR; exit }' "$file")
+  if [[ -z "$closing_line" ]]; then
+    echo "::error file=$file::Missing frontmatter closing delimiter (no second '---' found)"
+    errors=$((errors + 1))
+    # Bail out — remaining checks depend on valid frontmatter
+    continue
+  fi
+
+  # Extract frontmatter content (between the two --- lines)
+  frontmatter=$(sed -n "2,$((closing_line - 1))p" "$file")
+
+  # --- Check 3: name field exists ---
+  name_line=$(echo "$frontmatter" | grep -m1 '^name:')
+  if [[ -z "$name_line" ]]; then
+    echo "::error file=$file::Missing 'name' field in frontmatter"
+    errors=$((errors + 1))
+    file_errors=$((file_errors + 1))
+  else
+    # --- Check 4: name format ---
+    name_value=$(echo "$name_line" | sed 's/^name:[[:space:]]*//')
+    if [[ ! "$name_value" =~ ^[a-z0-9-]+$ ]]; then
+      echo "::error file=$file::Invalid name '$name_value' — must match ^[a-z0-9-]+$"
+      errors=$((errors + 1))
+      file_errors=$((file_errors + 1))
+    fi
+
+    # --- Check 5: name matches directory ---
+    if [[ "$name_value" != "$dir_name" ]]; then
+      echo "::error file=$file::Frontmatter name '$name_value' does not match directory name '$dir_name'"
+      errors=$((errors + 1))
+      file_errors=$((file_errors + 1))
+    fi
+  fi
+
+  # --- Check 6: description field ---
+  desc_line=$(echo "$frontmatter" | grep -m1 '^description:')
+  if [[ -z "$desc_line" ]]; then
+    echo "::error file=$file::Missing 'description' field in frontmatter"
+    errors=$((errors + 1))
+    file_errors=$((file_errors + 1))
+  else
+    desc_value=$(echo "$desc_line" | sed 's/^description:[[:space:]]*//')
+    if [[ -z "$desc_value" ]]; then
+      echo "::error file=$file::Empty 'description' field in frontmatter"
+      errors=$((errors + 1))
+      file_errors=$((file_errors + 1))
+    fi
+  fi
+
+  # --- Check 7: H1 heading after frontmatter ---
+  after_frontmatter=$(tail -n +"$((closing_line + 1))" "$file")
+  h1_found=$(echo "$after_frontmatter" | grep -m1 '^# ')
+  if [[ -z "$h1_found" ]]; then
+    echo "::error file=$file::Missing H1 heading (no '# ' line after frontmatter)"
+    errors=$((errors + 1))
+    file_errors=$((file_errors + 1))
+  fi
+
+  # --- Check 8: Standards section ---
+  standards_found=$(grep -c '^## Standards (Non-Negotiable)' "$file")
+  if [[ "$standards_found" -eq 0 ]]; then
+    echo "::error file=$file::Missing '## Standards (Non-Negotiable)' section"
+    errors=$((errors + 1))
+    file_errors=$((file_errors + 1))
+  fi
+
+  if [[ "$file_errors" -eq 0 ]]; then
+    echo "✅ $file"
+  fi
+done < <(find ./skills -maxdepth 2 -name "SKILL.md" | sort)
+
+echo ""
+if [[ $errors -gt 0 ]]; then
+  echo "❌ Validation failed with $errors error(s)."
+  exit 1
+else
+  echo "✅ All SKILL.md files are valid."
+fi


### PR DESCRIPTION
## Description

Closes #7 

Just in case we copy-paste skills from other places that skip the standards captured in CLAUDE.md, we're adding a CI check that validates for frontmatter, title, folder naming and standards section on every skill.

## Type of Change

<!--- Check the one that applies to this PR. -->

- [ ] New feature (`feat`)
- [ ] Bug fix (`fix`)
- [ ] Code refactor (`refactor`)
- [ ] Documentation (`docs`)
- [x] CI change (`ci`)
- [ ] Chore (`chore`)