### PR TITLE
chore: add code of conduct and issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -1,0 +1,39 @@
+name: Bug Report
+description: Create a report to help us improve
+title: "fix: "
+labels: [bug]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: A clear and concise description of what the bug is.
+      placeholder: "Describe the bug."
+    validations:
+      required: true
+  - type: textarea
+    id: setps-to-reproduce
+    attributes:
+      label: Steps To Reproduce
+      description: A set of instructions, step by step, explaining how to reproduce the bug.
+      placeholder: |
+        1. Go to '...'
+        2. Click on '....'
+        3. Scroll down to '....'
+        4. See error
+    validations:
+      required: true
+  - type: textarea
+    id: expected-behavior
+    attributes:
+      label: Expected Behavior
+      description: A clear and concise description of what you expected to happen.
+      placeholder: "Describe what you expected to happen."
+    validations:
+      required: true
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional Context
+      description: Add any other context, including links/screenshots/video recordings/etc about the problem here.
+      placeholder: "Provide context here."

--- a/.github/ISSUE_TEMPLATE/build.yaml
+++ b/.github/ISSUE_TEMPLATE/build.yaml
@@ -1,0 +1,29 @@
+name: Build System
+description: Changes that affect the build system or external dependencies
+title: "build: "
+labels: [build]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: Describe what changes need to be done to the build system and why
+      placeholder: "Describe the build system change."
+    validations:
+      required: true
+  - type: textarea
+    id: requirements
+    attributes:
+      label: Requirements
+      description: The list of requirements that need to be met in order to consider the ticket to be completed. Please be as explicit as possible.
+      value: |
+        - [ ] All CI/CD checks are passing.
+        - [ ] There is no drop in the test coverage percentage.
+    validations:
+      required: true
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional Context
+      description: Add any other context, including links/screenshots/video recordings/etc about the problem here.
+      placeholder: "Provide context here."

--- a/.github/ISSUE_TEMPLATE/chore.yaml
+++ b/.github/ISSUE_TEMPLATE/chore.yaml
@@ -1,0 +1,30 @@
+name: Chore
+description: Other changes that don't modify source or test files
+title: "chore: "
+labels: [chore]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: Clearly describe what change is needed and why. If this changes code then please use another issue type.
+      placeholder: "Provide a description of the chore."
+    validations:
+      required: true
+  - type: textarea
+    id: requirements
+    attributes:
+      label: Requirements
+      description: The list of requirements that need to be met in order to consider the ticket to be completed. Please be as explicit as possible.
+      value: |
+        - [ ] No functional changes to the code.
+        - [ ] All CI/CD checks are passing.
+        - [ ] There is no drop in the test coverage percentage.
+    validations:
+      required: true
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional Context
+      description: Add any other context, including links/screenshots/video recordings/etc about the problem here.
+      placeholder: "Provide context here."

--- a/.github/ISSUE_TEMPLATE/ci.yaml
+++ b/.github/ISSUE_TEMPLATE/ci.yaml
@@ -1,0 +1,29 @@
+name: Continuous Integration
+description: Changes to the CI configuration files and scripts
+title: "ci: "
+labels: [ci]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: Describe what changes need to be done to the CI/CD system and why.
+      placeholder: "Provide a description of the changes that need to be done to the CI/CD system."
+    validations:
+      required: true
+  - type: textarea
+    id: requirements
+    attributes:
+      label: Requirements
+      description: The list of requirements that need to be met in order to consider the ticket to be completed. Please be as explicit as possible.
+      value: |
+        - [ ] All CI/CD checks are passing.
+        - [ ] There is no drop in the test coverage percentage.
+    validations:
+      required: true
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional Context
+      description: Add any other context, including links/screenshots/video recordings/etc about the problem here.
+      placeholder: "Provide context here."

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/documentation.yaml
+++ b/.github/ISSUE_TEMPLATE/documentation.yaml
@@ -1,0 +1,30 @@
+name: Documentation
+description: Improve the documentation so all collaborators have a common understanding
+title: "docs: "
+labels: [documentation]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: Clearly describe what documentation you are looking to add or improve.
+      placeholder: "Provide a description of the documentation changes."
+    validations:
+      required: true
+  - type: textarea
+    id: requirements
+    attributes:
+      label: Requirements
+      description: The list of requirements that need to be met in order to consider the ticket to be completed. Please be as explicit as possible.
+      value: |
+        - [ ] No functional changes to the code.
+        - [ ] All CI/CD checks are passing.
+        - [ ] There is no drop in the test coverage percentage.
+    validations:
+      required: true
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional Context
+      description: Add any other context, including links/screenshots/video recordings/etc about the problem here.
+      placeholder: "Provide context here."

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -1,0 +1,29 @@
+name: Feature Request
+description: A new feature to be added to the project
+title: "feat: "
+labels: [feature]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: Clearly describe what you are looking to add. The more business/user context the better.
+      placeholder: "Provide a description of the feature."
+    validations:
+      required: true
+  - type: textarea
+    id: requirements
+    attributes:
+      label: Requirements
+      description: The list of requirements that need to be met in order to consider the ticket to be completed. Please be as explicit as possible.
+      value: |
+        - [ ] All CI/CD checks are passing.
+        - [ ] There is no drop in the test coverage percentage.
+    validations:
+      required: true
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional Context
+      description: Add any other context, including links/screenshots/video recordings/etc about the problem here.
+      placeholder: "Provide context here."

--- a/.github/ISSUE_TEMPLATE/performance.yaml
+++ b/.github/ISSUE_TEMPLATE/performance.yaml
@@ -1,0 +1,29 @@
+name: Performance Update
+description: A code change that improves performance
+title: "perf: "
+labels: [performance]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: Clearly describe what code needs to be changed and what the performance impact is going to be. Bonus point's if you can tie this directly to user experience.
+      placeholder: " Provide a description of the performance update."
+    validations:
+      required: true
+  - type: textarea
+    id: requirements
+    attributes:
+      label: Requirements
+      description: The list of requirements that need to be met in order to consider the ticket to be completed. Please be as explicit as possible.
+      value: |
+        - [ ] All CI/CD checks are passing.
+        - [ ] There is no drop in the test coverage percentage.
+    validations:
+      required: true
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional Context
+      description: Add any other context, including links/screenshots/video recordings/etc about the problem here.
+      placeholder: "Provide context here."

--- a/.github/ISSUE_TEMPLATE/refactor.yaml
+++ b/.github/ISSUE_TEMPLATE/refactor.yaml
@@ -1,0 +1,29 @@
+name: Refactor
+description: A code change that neither fixes a bug nor adds a feature
+title: "refactor: "
+labels: [refactor]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: Clearly describe what needs to be refactored and why. Please provide links to related issues (bugs or upcoming features) in order to help prioritize.
+      placeholder: "Provide a description of the refactor."
+    validations:
+      required: true
+  - type: textarea
+    id: requirements
+    attributes:
+      label: Requirements
+      description: The list of requirements that need to be met in order to consider the ticket to be completed. Please be as explicit as possible.
+      value: |
+        - [ ] All CI/CD checks are passing.
+        - [ ] There is no drop in the test coverage percentage.
+    validations:
+      required: true
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional Context
+      description: Add any other context, including links/screenshots/video recordings/etc about the problem here.
+      placeholder: "Provide context here."

--- a/.github/ISSUE_TEMPLATE/revert.yaml
+++ b/.github/ISSUE_TEMPLATE/revert.yaml
@@ -1,0 +1,30 @@
+name: Revert
+description: Revert a previous commit
+title: "revert: "
+labels: [revert]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: Provide a link to a PR/Commit that you are looking to revert and why.
+      placeholder: "Provide a description of and link to the commit that needs to be reverted."
+    validations:
+      required: true
+  - type: textarea
+    id: requirements
+    attributes:
+      label: Requirements
+      description: The list of requirements that need to be met in order to consider the ticket to be completed. Please be as explicit as possible.
+      value: |
+        - [ ] Change has been reverted.
+        - [ ] No change in unit/widget test coverage has happened.
+        - [ ] A new ticket is created for any follow on work that needs to happen.
+    validations:
+      required: true
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional Context
+      description: Add any other context, including links/screenshots/video recordings/etc about the problem here.
+      placeholder: "Provide context here."

--- a/.github/ISSUE_TEMPLATE/style.yaml
+++ b/.github/ISSUE_TEMPLATE/style.yaml
@@ -1,0 +1,29 @@
+name: Style
+description: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
+title: "style: "
+labels: [style]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: Clearly describe what you are looking to change and why.
+      placeholder: "Provide a description of the style changes."
+    validations:
+      required: true
+  - type: textarea
+    id: requirements
+    attributes:
+      label: Requirements
+      description: The list of requirements that need to be met in order to consider the ticket to be completed. Please be as explicit as possible.
+      value: |
+        - [ ] All CI/CD checks are passing.
+        - [ ] There is no drop in the unit or widget test coverage percentage.
+    validations:
+      required: true
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional Context
+      description: Add any other context, including links/screenshots/video recordings/etc about the problem here.
+      placeholder: "Provide context here."

--- a/.github/ISSUE_TEMPLATE/test.yaml
+++ b/.github/ISSUE_TEMPLATE/test.yaml
@@ -1,0 +1,29 @@
+name: Test
+description: Adding missing tests or correcting existing tests
+title: "test: "
+labels: [test]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: List out the tests that need to be added or changed. Please also include any information as to why this was not covered in the past.
+      placeholder: "Provide a description of the tests that need to be added or changed."
+    validations:
+      required: true
+  - type: textarea
+    id: requirements
+    attributes:
+      label: Requirements
+      description: The list of requirements that need to be met in order to consider the ticket to be completed. Please be as explicit as possible.
+      value: |
+        - [ ] All CI/CD checks are passing.
+        - [ ] There is no drop in the test coverage percentage.
+    validations:
+      required: true
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional Context
+      description: Add any other context, including links/screenshots/video recordings/etc about the problem here.
+      placeholder: "Provide context here."

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,76 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, sex characteristics, gender identity and expression,
+level of experience, education, socio-economic status, nationality, personal
+appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Gracefully accepting constructive criticism
+- Focusing on what is best for the community
+- Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+- The use of sexualized language or imagery and unwelcome sexual attention or
+  advances
+- Trolling, insulting/derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at hello@verygood.ventures. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see
+https://www.contributor-covenant.org/faq/


### PR DESCRIPTION
## Summary
- Add Contributor Covenant Code of Conduct (v1.4) with VGV enforcement contact
- Add 11 GitHub issue templates (bug report, feature request, docs, chore, CI, build, performance, refactor, revert, style, test) matching the [very_good_cli](https://github.com/VeryGoodOpenSource/very_good_cli) standard
- Disable blank issues via `config.yml`

## Test plan
- [ ] Verify issue templates render correctly on the GitHub "New Issue" page
- [ ] Confirm `CODE_OF_CONDUCT.md` is linked automatically by GitHub in the repo sidebar

🤖 Generated with [Claude Code](https://claude.com/claude-code)