### PR TITLE
feat: support AGENTS.md standard

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,10 +1,10 @@
-# CLAUDE.md
+# AGENTS.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository. See [`AGENTS.md`](AGENTS.md) for platform-agnostic repo conventions.
+This file provides repository conventions to AI coding agents working with this codebase. It is the platform-agnostic companion to `CLAUDE.md`, which contains Claude Code-specific extensions.
 
 ## Project Overview
 
-Very Good AI Flutter Plugin is a Claude Code plugin that provides best-practices skills for Flutter and Dart development. It is a **documentation-only repository** — there is no Dart/Flutter source code, no `pubspec.yaml`, and no tests. All value lives in the markdown skill files.
+Very Good AI Flutter Plugin provides best-practices skills for Flutter and Dart development. It is a **documentation-only repository** — there is no Dart/Flutter source code, no `pubspec.yaml`, and no tests. All value lives in the markdown skill files.
 
 ## Repository Structure
 
@@ -67,7 +67,7 @@ Every `SKILL.md` follows this structure:
 1. Create `skills/<skill_name>/SKILL.md` following the format above
 2. Update tags in `.claude-plugin/plugin.json`
 3. Update the skills table in `README.md` (skill name must link to the `SKILL.md` file)
-4. Update the repository structure in `CLAUDE.md` and `AGENTS.md`
+4. Update the repository structure in `AGENTS.md` and `CLAUDE.md`
 
 ## Hooks
 
@@ -86,7 +86,7 @@ Both PreToolUse scripts share common utilities from `vgv-cli-common.sh`.
 
 These run **after** a tool call completes:
 
-- `Edit|Write` matcher → `analyze.sh` — runs `dart analyze` on the modified `.dart` file; exits 2 on failure (blocking — Claude must fix the issue)
+- `Edit|Write` matcher → `analyze.sh` — runs `dart analyze` on the modified `.dart` file; exits 2 on failure (blocking — the agent must fix the issue)
 - `Edit|Write` matcher → `format.sh` — runs `dart format` on the modified `.dart` file; always exits 0 (non-blocking)
 
 All hook scripts require **jq** to parse the hook payload (they skip gracefully if `jq` is not installed).

--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@ Developed with 💙 by [Very Good Ventures][vgv_link] 🦄
 
 Very Good AI Flutter Plugin is a collection of contextual best-practices skills that Claude uses when helping you write Flutter and Dart code. Each skill provides opinionated, production-quality guidance covering architecture patterns, naming conventions, folder structures, code examples, testing strategies, and anti-patterns to avoid, so you get code that follows [VGV standards][vgv_link] out of the box.
 
+## Agent Compatibility
+
+This repository includes an [`AGENTS.md`](AGENTS.md) file that provides repo conventions to any AI coding agent. Any agent that reads `AGENTS.md` at the repository root will understand the skill format, writing conventions, hooks, and contribution workflow.
+
 ## Installation
 
 ### From the Marketplace
@@ -39,6 +43,7 @@ For more details, see the [Very Good Claude Marketplace][marketplace_link].
 | [**Security**](skills/static-security/SKILL.md) | Flutter-specific static security review — secrets management, `flutter_secure_storage`, certificate pinning, `Random.secure()`, `formz` validation, dependency vulnerability scanning with `osv-scanner`, and OWASP Mobile Top 10 guidance |
 | [**License Compliance**](skills/license-compliance/SKILL.md) | Dependency license auditing — categorizes licenses (permissive, weak/strong copyleft, unknown), flags non-compliant or missing licenses, and produces a structured compliance report using Very Good CLI |
 | [**Dart/Flutter SDK Upgrade**](skills/dart-flutter-sdk-upgrade/SKILL.md) | Bump Dart and Flutter SDK constraints across packages — CI workflow versions, pubspec.yaml environment constraints, and PR preparation for SDK upgrades |
+| [**Very Good Analysis Upgrade**](skills/very-good-analysis-upgrade/SKILL.md) | Upgrade `very_good_analysis` lint package — version bump, lint fixes for new rules, and focused PR creation |
 
 ## Hooks
 


### PR DESCRIPTION
## Description

Add `AGENTS.md` to support the [AGENTS.md open standard](https://agents.md/) for cross-platform AI coding agent compatibility. This allows tools like Codex, Cursor, Copilot, and Windsurf to understand repo conventions alongside Claude Code.

`AGENTS.md` contains platform-agnostic repo conventions (project overview, repository structure, skill format, writing guidelines, hooks, and commit format) derived from the existing `CLAUDE.md`. Both files currently carry full content because Claude Code does not yet natively read `AGENTS.md` ([anthropics/claude-code#34235](https://github.com/anthropics/claude-code/issues/34235), [anthropics/claude-code#6235](https://github.com/anthropics/claude-code/issues/6235)). Once that lands, `CLAUDE.md` can be slimmed to Claude-specific extensions only.

Also fixes the missing `very-good-analysis-upgrade` skill entry in the repository structure trees (CLAUDE.md, AGENTS.md) and README skills table — it was added in #57 but these files were not updated.

Closes #49

## Type of Change

- [x] New feature (`feat`)