### PR TITLE
docs: add one-line install command to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,15 @@ VGV AI Flutter Plugin is a collection of contextual best-practices skills that C
 
 ## Installation
 
-### From the Marketplace
+One command. Done.
 
-Inside Claude Code:
+From a terminal:
+
+```bash
+claude plugin marketplace add VeryGoodOpenSource/very_good_claude_marketplace && claude plugin install vgv-ai-flutter-plugin@very-good-claude-code-marketplace
+```
+
+Or inside a Claude Code session:
 
 ```bash
 /plugin marketplace add VeryGoodOpenSource/very_good_claude_marketplace

--- a/README.md
+++ b/README.md
@@ -13,15 +13,13 @@ VGV AI Flutter Plugin is a collection of contextual best-practices skills that C
 
 ## Installation
 
-One command. Done.
-
-From a terminal:
+One-line install from your terminal:
 
 ```bash
 claude plugin marketplace add VeryGoodOpenSource/very_good_claude_marketplace && claude plugin install vgv-ai-flutter-plugin@very-good-claude-code-marketplace
 ```
 
-Or inside a Claude Code session:
+Or inside an active Claude Code session:
 
 ```bash
 /plugin marketplace add VeryGoodOpenSource/very_good_claude_marketplace


### PR DESCRIPTION
## Summary
- Add a terminal one-liner using the `claude plugin` CLI so users can install the plugin in a single command from outside a Claude Code session.
- Keep the existing in-session `/plugin` instructions for users already inside Claude Code.

## Test plan
- [x] Render README on GitHub and confirm both install blocks display correctly.
- [x] Run the terminal one-liner in a fresh shell and verify the plugin installs end-to-end.
- [x] Run the in-session commands inside Claude Code and verify the plugin installs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)