### PR TITLE
fix(skills): split description and when_to_use, drop unsupported effort field

### DIFF
--- a/skills/accessibility/SKILL.md
+++ b/skills/accessibility/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: vgv-accessibility
-description: Flutter accessibility auditing and remediation with WCAG 2.1 level selection (A, AA, AAA) across mobile, desktop, and web platforms. Use when building, auditing, or reviewing widgets for screen reader support, touch targets, focus management, color contrast, text scaling, or motion sensitivity. Begins by asking the WCAG conformance level and target platform(s) before applying level-appropriate, platform-aware criteria.
+description: Flutter accessibility auditing and remediation with WCAG 2.1 level selection (A, AA, AAA) across mobile, desktop, and web platforms. Begins by asking the WCAG conformance level and target platform(s) before applying level-appropriate, platform-aware criteria.
+when_to_use: Use when building, auditing, or reviewing widgets for screen reader support, touch targets, focus management, color contrast, text scaling, or motion sensitivity.
 argument-hint: "[wcag-level] [platform]"
 allowed-tools: Read Glob Grep
 effort: high

--- a/skills/bloc/SKILL.md
+++ b/skills/bloc/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: vgv-bloc
-description: Best practices for Bloc state management in Flutter/Dart. Use when writing, modifying, or reviewing code that uses package:bloc, package:flutter_bloc, or package:bloc_test.
+description: Best practices for Bloc state management in Flutter/Dart.
+when_to_use: Use when writing, modifying, or reviewing code that uses package:bloc, package:flutter_bloc, or package:bloc_test.
 allowed-tools: Read Glob Grep
 ---
 

--- a/skills/create-project/SKILL.md
+++ b/skills/create-project/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: vgv-create-project
-description: Scaffold a new Dart or Flutter project from a Very Good CLI template. Use when user says "create a new project", "start a new flutter app", "scaffold a package", "initialize a dart cli", "new flame game", or "generate a plugin". Supports flutter_app, dart_package, flutter_package, flutter_plugin, dart_cli, flame_game, and docs_site templates.
+description: Scaffold a new Dart or Flutter project from a Very Good CLI template. Supports flutter_app, dart_package, flutter_package, flutter_plugin, dart_cli, flame_game, and docs_site templates.
+when_to_use: Use when user says "create a new project", "start a new flutter app", "scaffold a package", "initialize a dart cli", "new flame game", or "generate a plugin".
 allowed-tools: mcp__very-good-cli__create mcp__very-good-cli__packages_get
 argument-hint: "[template] [project-name]"
 model: haiku
-effort: low
 ---
 
 # Create Project

--- a/skills/dart-flutter-sdk-upgrade/SKILL.md
+++ b/skills/dart-flutter-sdk-upgrade/SKILL.md
@@ -2,12 +2,13 @@
 name: vgv-dart-flutter-sdk-upgrade
 description: >
   VGV-specific reference for bumping Dart and Flutter SDK constraints across packages.
-  Use when upgrading the Flutter or Dart SDK version in any VGV repository — bumping
-  pubspec.yaml environment constraints, updating CI workflow Flutter versions, or preparing
-  an SDK upgrade PR. CI uses ^MAJOR.MINOR.x to resolve to the latest patch; pubspec pins
-  the exact patch version (e.g., ^3.50.1). Trigger on phrases like "bump Flutter to 3.x",
-  "update SDK constraints", "upgrade Dart SDK", "update CI Flutter version",
-  "bump SDK version", or "prep the SDK upgrade PR".
+  Covers pubspec.yaml environment constraints, CI workflow Flutter versions, and SDK
+  upgrade PR preparation. CI uses ^MAJOR.MINOR.x to resolve to the latest patch;
+  pubspec pins the exact patch version (e.g., ^3.50.1).
+when_to_use: >
+  Use when upgrading the Flutter or Dart SDK version in any VGV repository. Trigger on
+  phrases like "bump Flutter to 3.x", "update SDK constraints", "upgrade Dart SDK",
+  "update CI Flutter version", "bump SDK version", or "prep the SDK upgrade PR".
 allowed-tools: Read Glob Grep Edit Write Bash
 model: sonnet
 effort: medium

--- a/skills/internationalization/SKILL.md
+++ b/skills/internationalization/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: vgv-internationalization
-description: Best practices for internationalization (i18n) and localization (l10n) in Flutter. Use when adding, modifying, or reviewing ARB translations, locale setup, BuildContext l10n extensions, or RTL/directional layout support.
+description: Best practices for internationalization (i18n) and localization (l10n) in Flutter.
+when_to_use: Use when adding, modifying, or reviewing ARB translations, locale setup, BuildContext l10n extensions, or RTL/directional layout support.
 allowed-tools: Read Glob Grep
 model: sonnet
 ---

--- a/skills/layered-architecture/SKILL.md
+++ b/skills/layered-architecture/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: vgv-layered-architecture
-description: Best practices for VGV layered monorepo architecture in Flutter. Use when structuring a multi-package Flutter app, creating data or repository packages, defining layer boundaries, or wiring dependencies between packages.
+description: Best practices for VGV layered monorepo architecture in Flutter.
+when_to_use: Use when structuring a multi-package Flutter app, creating data or repository packages, defining layer boundaries, or wiring dependencies between packages.
 allowed-tools: Read Glob Grep mcp__very-good-cli__create mcp__very-good-cli__packages_get mcp__very-good-cli__test
 effort: high
 ---

--- a/skills/license-compliance/SKILL.md
+++ b/skills/license-compliance/SKILL.md
@@ -3,6 +3,7 @@ name: vgv-license-compliance
 description: >
   Audits package dependency licenses using the Very Good CLI packages_check_licenses
   MCP tool. Flags non-compliant or unknown licenses and produces a compliance summary.
+when_to_use: >
   Use when user says "check licenses", "license audit", "are our dependencies compliant",
   "check dependency licenses", "license compliance", "review package licenses",
   "scan for license issues", or "pre-release license check".

--- a/skills/material-theming/SKILL.md
+++ b/skills/material-theming/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: vgv-material-theming
-description: Best practices for Flutter theming using Material 3. Use when creating, modifying, or reviewing ThemeData, ColorScheme, TextTheme, component themes, spacing systems, or light/dark mode support.
+description: Best practices for Flutter theming using Material 3.
+when_to_use: Use when creating, modifying, or reviewing ThemeData, ColorScheme, TextTheme, component themes, spacing systems, or light/dark mode support.
 allowed-tools: Read Glob Grep
 model: sonnet
 ---

--- a/skills/navigation/SKILL.md
+++ b/skills/navigation/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: vgv-navigation
-description: Best practices for navigation and routing in Flutter using GoRouter. Use when creating, modifying, or reviewing routes, deep links, redirects, or navigation logic that uses package:go_router or package:go_router_builder.
+description: Best practices for navigation and routing in Flutter using GoRouter.
+when_to_use: Use when creating, modifying, or reviewing routes, deep links, redirects, or navigation logic that uses package:go_router or package:go_router_builder.
 allowed-tools: Read Glob Grep
 model: sonnet
 ---

--- a/skills/static-security/SKILL.md
+++ b/skills/static-security/SKILL.md
@@ -1,9 +1,11 @@
 ---
 name: vgv-static-security
 description: >
-  Best practices for Flutter mobile app security. Use when reviewing or writing
-  code that handles secrets, user data, network communication, authentication,
-  or cryptography. Covers static security concerns — not pen-testing or runtime analysis.
+  Best practices for Flutter mobile app security. Covers static security concerns —
+  not pen-testing or runtime analysis.
+when_to_use: >
+  Use when reviewing or writing code that handles secrets, user data, network
+  communication, authentication, or cryptography.
 argument-hint: "[file-or-directory]"
 allowed-tools: Read Glob Grep mcp__very-good-cli__packages_check_licenses
 effort: high

--- a/skills/testing/SKILL.md
+++ b/skills/testing/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: vgv-testing
-description: Best practices for Dart unit tests, Flutter widget tests, and golden file tests. Use when writing, modifying, or reviewing tests that use package:test, package:flutter_test, package:mocktail, or package:bloc_test.
+description: Best practices for Dart unit tests, Flutter widget tests, and golden file tests.
+when_to_use: Use when writing, modifying, or reviewing tests that use package:test, package:flutter_test, package:mocktail, or package:bloc_test.
 argument-hint: "[file-or-directory]"
 allowed-tools: Read Glob Grep mcp__very-good-cli__test
 ---

--- a/skills/ui-package/SKILL.md
+++ b/skills/ui-package/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: vgv-ui-package
-description: Best practices for building a Flutter UI package on top of Material — custom components, ThemeExtension-based theming, consistent APIs, and widget tests. Use when user says "create a ui package". Supports app_ui_package template.
+description: Best practices for building a Flutter UI package on top of Material — custom components, ThemeExtension-based theming, consistent APIs, and widget tests. Supports app_ui_package template.
+when_to_use: Use when user says "create a ui package".
 allowed-tools: Edit mcp__very-good-cli__create
 model: sonnet
 ---


### PR DESCRIPTION
## Description

Aligns skill frontmatter across the plugin with the latest [Claude Code skills](https://code.claude.com/docs/en/skills) and [Agent Skills open spec](https://agentskills.io/specification).

**Authoring split: `description` vs `when_to_use`**

Skills mixed "what it does" with trigger phrases ("Use when ...") in a single `description`. Split into `description` (what) and `when_to_use` (triggers) per Claude Code skills guidance. Applied to 12 skills:

- accessibility, bloc, create-project, dart-flutter-sdk-upgrade, internationalization, layered-architecture, license-compliance, material-theming, navigation, static-security, testing, ui-package
- `very-good-analysis-upgrade` left untouched (no trigger tail in description)

**Drop unsupported `effort` field**

Removed `effort: low` from `create-project` (uses `model: haiku`). The `effort` field is only supported on Opus 4.7/4.6 and Sonnet 4.6, silently ignored on Haiku per [model-config docs](https://code.claude.com/docs/en/model-config).

Verified locally: `claude plugin validate .` → ✔ Validation passed

## Type of Change

- [ ] New feature (`feat`)
- [x] Bug fix (`fix`)
- [ ] Code refactor (`refactor`)
- [ ] Documentation (`docs`)
- [ ] CI change (`ci`)
- [ ] Chore (`chore`)