### PR TITLE
docs: fix install command and clarify in-session steps in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,15 +16,22 @@ VGV AI Flutter Plugin is a collection of contextual best-practices skills that C
 One-line install from your terminal:
 
 ```bash
-claude plugin marketplace add VeryGoodOpenSource/very_good_claude_marketplace && claude plugin install vgv-ai-flutter-plugin@very-good-claude-code-marketplace
+claude plugin marketplace add VeryGoodOpenSource/very_good_claude_marketplace && claude plugin install vgv-ai-flutter-plugin
 ```
 
-Or inside an active Claude Code session:
+Or inside an active Claude Code session, run these as **two separate commands** (the second only after the first completes):
 
-```bash
-/plugin marketplace add VeryGoodOpenSource/very_good_claude_marketplace
-/plugin install vgv-ai-flutter-plugin@very-good-claude-code-marketplace
-```
+1. Add the marketplace:
+
+   ```text
+   /plugin marketplace add VeryGoodOpenSource/very_good_claude_marketplace
+   ```
+
+2. Install the plugin:
+
+   ```text
+   /plugin install vgv-ai-flutter-plugin
+   ```
 
 For more details, see the [Very Good Claude Marketplace][marketplace_link].
 


### PR DESCRIPTION
## Description

Mirrors [vgv-wingspan#196](https://github.com/VeryGoodOpenSource/vgv-wingspan/pull/196) and [vgv-wingspan#197](https://github.com/VeryGoodOpenSource/vgv-wingspan/pull/197) for this plugin's README:

- Drop the `@very-good-claude-code-marketplace` suffix from both install commands so they resolve correctly (same fix vgv-wingspan applied to its install).
- Split the in-session install into two numbered `/plugin` steps with a note that the second command must run only after the first completes — Claude Code requires separate invocations for `/plugin marketplace add` and `/plugin install`, so the prior single code block could mislead users into pasting both at once.
- Switch the in-session code-block language tag from `bash` to `text` since slash commands are not shell input.

## Type of Change

- [ ] New feature (`feat`)
- [ ] Bug fix (`fix`)
- [ ] Code refactor (`refactor`)
- [x] Documentation (`docs`)
- [ ] CI change (`ci`)
- [ ] Chore (`chore`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)