### PR TITLE
docs: fix marketplace name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ VGV AI Flutter Plugin is a collection of contextual best-practices skills that C
 One-line install from your terminal:
 
 ```bash
-claude plugin marketplace add VeryGoodOpenSource/very_good_claude_marketplace && claude plugin install vgv-ai-flutter-plugin
+claude plugin marketplace add VeryGoodOpenSource/very-good-claude-code-marketplace && claude plugin install vgv-ai-flutter-plugin
 ```
 
 Or inside an active Claude Code session, run these as **two separate commands** (the second only after the first completes):
@@ -24,7 +24,7 @@ Or inside an active Claude Code session, run these as **two separate commands** 
 1. Add the marketplace:
 
    ```text
-   /plugin marketplace add VeryGoodOpenSource/very_good_claude_marketplace
+   /plugin marketplace add VeryGoodOpenSource/very-good-claude-code-marketplace
    ```
 
 2. Install the plugin:
@@ -133,7 +133,7 @@ This plugin includes a `.mcp.json` configuration that connects Claude Code to th
 
 The `.mcp.json` file at the project root registers a `very-good-cli` MCP server using stdio transport. When Claude Code detects this configuration, it connects to the Very Good CLI MCP server and gains access to the tools above. The skills continue to provide knowledge and best practices while the MCP tools handle execution.
 
-[marketplace_link]: https://github.com/VeryGoodOpenSource/very_good_claude_marketplace
+[marketplace_link]: https://github.com/VeryGoodOpenSource/very-good-claude-code-marketplace
 [claude_code_link]: https://claude.ai/code
 [vgv_link]: https://verygood.ventures
 [very_good_ventures_link_dark]: https://verygood.ventures#gh-dark-mode-only


### PR DESCRIPTION
## Description

The marketplace name is incorrect in the README. Update from `very_good_claude_marketplace` to `very-good-claude-code-marketplace` (3 occurrences: terminal install command, in-session `/plugin marketplace add` command, and the `[marketplace_link]` reference).

The canonical marketplace repo and the `name` field in its [marketplace.json](https://github.com/VeryGoodOpenSource/very-good-claude-code-marketplace/blob/main/.claude-plugin/marketplace.json) both use `very-good-claude-code-marketplace`. The current README name (`very_good_claude_marketplace`) uses underscores and is missing `code`.

Mirrors the same fix from [vgv-wingspan#190](https://github.com/VeryGoodOpenSource/vgv-wingspan/pull/190), which flagged this repo as having the related issue.

## Type of Change

- [x] Documentation (`docs`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)