### PR TITLE
fix: require very_good_cli >= 1.3.0 to resolve MCP test hang

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@ hooks/
   scripts/
     analyze.sh         # Runs dart analyze on modified .dart files
     block-cli-workarounds.sh  # Prevents direct CLI bypass via Bash
-    check-vgv-cli.sh   # Validates VGV CLI installed and >= 1.2.0
+    check-vgv-cli.sh   # Validates VGV CLI installed and >= 1.3.0
     format.sh          # Runs dart format on modified .dart files
     vgv-cli-common.sh  # Shared utilities for VGV CLI hook scripts
     warn-missing-mcp.sh  # Warns at session start if VGV CLI is missing/outdated
@@ -107,13 +107,13 @@ The `hooks/` directory contains SessionStart, PreToolUse, and PostToolUse hooks 
 
 These run **when a session begins**:
 
-- `warn-missing-mcp.sh` — checks if Very Good CLI is installed and >= 1.2.0; outputs a warning to Claude's context if missing or outdated (non-blocking)
+- `warn-missing-mcp.sh` — checks if Very Good CLI is installed and >= 1.3.0; outputs a warning to Claude's context if missing or outdated (non-blocking)
 
 ### PreToolUse Hooks
 
 These run **before** a tool call is executed:
 
-- `mcp__very-good-cli__.*` matcher → `check-vgv-cli.sh` — validates that the Very Good CLI is installed and at version >= 1.2.0; exits 2 on failure (blocking)
+- `mcp__very-good-cli__.*` matcher → `check-vgv-cli.sh` — validates that the Very Good CLI is installed and at version >= 1.3.0; exits 2 on failure (blocking)
 - `Bash` matcher → `block-cli-workarounds.sh` — prevents direct CLI bypass of VGV CLI commands through the Bash tool; exits 2 on failure (blocking)
 
 Both PreToolUse scripts share common utilities from `vgv-cli-common.sh`.

--- a/README.md
+++ b/README.md
@@ -60,8 +60,8 @@ This plugin includes SessionStart, PreToolUse, and PostToolUse hooks that valida
 
 | Hook | Trigger | Behavior |
 | ---- | ------- | -------- |
-| **Warn Missing MCP** (`warn-missing-mcp.sh`) | SessionStart | Warns if the Very Good CLI is missing or older than 1.2.0; non-blocking |
-| **Check VGV CLI** (`check-vgv-cli.sh`) | PreToolUse (`mcp__very-good-cli__.*`) | Validates the Very Good CLI is installed and ≥ 1.2.0; exits 2 on failure (blocking) |
+| **Warn Missing MCP** (`warn-missing-mcp.sh`) | SessionStart | Warns if the Very Good CLI is missing or older than 1.3.0; non-blocking |
+| **Check VGV CLI** (`check-vgv-cli.sh`) | PreToolUse (`mcp__very-good-cli__.*`) | Validates the Very Good CLI is installed and ≥ 1.3.0; exits 2 on failure (blocking) |
 | **Block CLI Workarounds** (`block-cli-workarounds.sh`) | PreToolUse (`Bash`) | Blocks direct CLI bypass of Very Good CLI commands through the Bash tool; exits 2 on failure (blocking) |
 | **Analyze** (`analyze.sh`) | PostToolUse (`Edit`/`Write`) | Runs `dart analyze` on the modified `.dart` file; exits 2 on failure (blocking — Claude must fix issues before continuing) |
 | **Format** (`format.sh`) | PostToolUse (`Edit`/`Write`) | Runs `dart format` on the modified `.dart` file; always exits 0 (non-blocking — formatting is applied silently) |
@@ -150,7 +150,7 @@ The Very Good CLI MCP server exposes Very Good CLI commands to Claude.
 
 **Prerequisites:**
 
-- Very Good CLI v1.2.0+ installed: `dart pub global activate very_good_cli`
+- Very Good CLI v1.3.0+ installed: `dart pub global activate very_good_cli`
 - `very_good` must be on your PATH
 
 **How it works:**

--- a/hooks/scripts/vgv-cli-common.sh
+++ b/hooks/scripts/vgv-cli-common.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 # Shared helpers for Very Good CLI version checks and hook deny responses.
 
-MIN_VERSION="1.2.0"
+MIN_VERSION="1.3.0"
 MIN_MAJOR=1
-MIN_MINOR=2
+MIN_MINOR=3
 MIN_PATCH=0
 
 deny() {

--- a/skills/testing/SKILL.md
+++ b/skills/testing/SKILL.md
@@ -27,6 +27,7 @@ Apply these standards to ALL test work:
 - **Use `pumpApp` test helper** — wrap widgets via shared helper in `test/helpers/pump_app.dart`; never inline `pumpWidget(MaterialApp(...))`
 - **Tag all golden tests** — annotate with `TestTag.golden` so goldens can run/update independently
 - **Pass `directory` to the `test` MCP tool when the project is not at the workspace root** — monorepos with the Flutter project in a subdirectory (e.g. `mobile/`) require `directory: 'mobile'`; omit it only when `pubspec.yaml` is at the workspace root
+- **Pass `timeout_seconds` to the `test` MCP tool** — Flutter tests can hang indefinitely when `pumpAndSettle()` is called without a timeout; set a cap (e.g. `timeout_seconds: 120`) so the run is killed instead of stalling
 
 ## Test Structure
 
@@ -473,6 +474,6 @@ Always call `pump()` (or `pumpAndSettle()`) after every interaction — widgets 
 - [references/widget-tests.md](references/widget-tests.md) — widget test structure and themes/localization testing
 - [references/golden-tests.md](references/golden-tests.md) — golden file testing (setup, writing goldens, tagging, running/updating, anti-patterns)
 - [references/matchers.md](references/matchers.md) — matchers quick reference
-- [references/configuration.md](references/configuration.md) — `dart_test.yaml` configuration (tags, commands, platform overrides)
+- [references/configuration.md](references/configuration.md) — `dart_test.yaml` configuration (tags, platform overrides) and running tests via the MCP `test` tool
 - [references/coverage.md](references/coverage.md) — coverage patterns and package/imports reference
 - [references/animation-testing.md](references/animation-testing.md) — testing implicit/explicit animations, AnimatedSwitcher, page transitions, and injected controllers

--- a/skills/testing/references/configuration.md
+++ b/skills/testing/references/configuration.md
@@ -70,16 +70,20 @@ test('renders correctly', tags: TestTag.golden, () {
 });
 ```
 
-## Common Commands
+## Running Tests
 
-| Command | Purpose |
-| --- | --- |
-| `dart test` | Run all Dart tests |
-| `flutter test` | Run all Flutter tests |
-| `dart test test/src/models/user_test.dart` | Run a specific test file |
-| `dart test --name "returns"` | Filter tests by description substring |
-| `dart test --tags unit` | Run only tests with the `unit` tag |
-| `dart test --exclude-tags integration` | Skip integration-tagged tests |
-| `flutter test --coverage` | Generate `coverage/lcov.info` |
-| `dart test --test-randomize-ordering-seed random` | Randomize test execution order |
-| `dart test --reporter expanded` | Verbose test output |
+Run tests through the `very_good_cli` MCP `test` tool — never `dart test` or `flutter test` via the shell (the `block-cli-workarounds` hook denies those). Pass `timeout_seconds` to cap the run so a hung `pumpAndSettle()` cannot stall it indefinitely.
+
+| Goal | MCP `test` tool parameters |
+| ---- | -------------------------- |
+| Run all tests (Flutter auto-detected) | _(no parameters)_ |
+| Run Dart tests | `dart: true` |
+| Run tests in a subdirectory | `directory: 'mobile'` |
+| Run only tests with a tag | `tags: 'unit'` |
+| Skip tests with a tag | `exclude_tags: 'integration'` |
+| Generate coverage (`coverage/lcov.info`) | `coverage: true` |
+| Enforce a minimum coverage percentage | `min_coverage: '100'` |
+| Run on a specific platform | `platform: 'chrome'` |
+| Randomize test execution order | `test_randomize_ordering_seed: 'random'` |
+| Run recursively across nested packages | `recursive: true` |
+| Cap runtime to avoid a hung test process | `timeout_seconds: 120` |

--- a/skills/testing/references/golden-tests.md
+++ b/skills/testing/references/golden-tests.md
@@ -76,12 +76,14 @@ testWidgets('matches golden', tags: TestTag.golden, (tester) async {
 
 ## Running and Updating Goldens
 
-| Command | Purpose |
-| --- | --- |
-| `flutter test --tags golden` | Run only golden tests |
-| `flutter test --tags golden --update-goldens` | Regenerate golden reference files |
-| `flutter test --exclude-tags golden` | Run all tests except goldens |
-| `flutter test` | Run all tests including goldens |
+Run goldens through the `very_good_cli` MCP `test` tool — never `flutter test` via the shell (the `block-cli-workarounds` hook denies it).
+
+| Goal | MCP `test` tool parameters |
+| ---- | -------------------------- |
+| Run only golden tests | `tags: 'golden'` |
+| Regenerate golden reference files | `tags: 'golden', update_goldens: true` |
+| Run all tests except goldens | `exclude_tags: 'golden'` |
+| Run all tests including goldens | _(no parameters)_ |
 
 After updating goldens, review and commit the new `.png` files --- they are the source of truth.
 


### PR DESCRIPTION
## Description

The `very_good_cli` MCP `test` tool hung during `/build` (issue #94). Root cause was twofold:

1. **No hang guard** — Flutter tests stall indefinitely when `pumpAndSettle()` runs without a timeout. CLI **1.3.0** adds a `timeout_seconds` parameter that kills a stuck run, so this bumps the minimum enforced version from `1.2.0` to `1.3.0`.
2. **Contradictory docs** — the testing skill references told Claude to run `dart test` / `flutter test`, which `block-cli-workarounds.sh` denies and redirects to the MCP `test` tool. That redirect dead-ended on the hang. The references now point at the MCP `test` tool directly.

### Changes

- `hooks/scripts/vgv-cli-common.sh` — `MIN_VERSION` `1.2.0` → `1.3.0`, `MIN_MINOR` `2` → `3` (the enforced check; other scripts read these vars).
- `README.md`, `CLAUDE.md` — version text updated to `1.3.0` (5 spots).
- `skills/testing/references/configuration.md` — "Common Commands" shell table replaced with an MCP `test` tool parameter table; no `dart test` / `flutter test` fallback left.
- `skills/testing/references/golden-tests.md` — golden command table converted to MCP `test` tool parameters.
- `skills/testing/SKILL.md` — new core standard to pass `timeout_seconds` to the `test` tool; reference description updated.

### Reviewer notes

- `dart test` / `flutter test` still appear in the references **only** inside "never use via shell" warnings.
- Acceptance criterion "live `/build` demo passes end-to-end" needs a manual run with CLI 1.3.0 installed.

Closes #94

## Type of Change

- [ ] New feature (`feat`)
- [x] Bug fix (`fix`)
- [ ] Code refactor (`refactor`)
- [ ] Documentation (`docs`)
- [ ] CI change (`ci`)
- [ ] Chore (`chore`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)