### PR TITLE
fix: auto-allow Very Good CLI MCP tools in all run modes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,7 +113,7 @@ These run **when a session begins**:
 
 These run **before** a tool call is executed:
 
-- `mcp__very-good-cli__.*` matcher → `check-vgv-cli.sh` — validates that the Very Good CLI is installed and at version >= 1.3.0; exits 2 on failure (blocking)
+- `mcp__.*very-good-cli__.*` matcher → `check-vgv-cli.sh` — auto-approves the Very Good CLI MCP tool call by returning a PreToolUse `allow` decision, so it is always permitted regardless of run mode (interactive, headless, or `skipAutoPermissionPrompt`) and never dead-ends when the tool isn't on `permissions.allow`; denies with an install/upgrade message if the CLI is missing or < 1.3.0. The `.*` in the matcher covers both the bare `mcp__very-good-cli__*` server (repo-root `.mcp.json`) and the plugin-namespaced `mcp__plugin_<plugin>_very-good-cli__*` form used when installed from a marketplace
 - `Bash` matcher → `block-cli-workarounds.sh` — prevents direct CLI bypass of VGV CLI commands through the Bash tool; exits 2 on failure (blocking)
 
 Both PreToolUse scripts share common utilities from `vgv-cli-common.sh`.

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ This plugin includes SessionStart, PreToolUse, and PostToolUse hooks that valida
 | Hook | Trigger | Behavior |
 | ---- | ------- | -------- |
 | **Warn Missing MCP** (`warn-missing-mcp.sh`) | SessionStart | Warns if the Very Good CLI is missing or older than 1.3.0; non-blocking |
-| **Check VGV CLI** (`check-vgv-cli.sh`) | PreToolUse (`mcp__very-good-cli__.*`) | Validates the Very Good CLI is installed and ≥ 1.3.0; exits 2 on failure (blocking) |
+| **Check VGV CLI** (`check-vgv-cli.sh`) | PreToolUse (`mcp__.*very-good-cli__.*`) | Auto-approves Very Good CLI MCP tool calls in every run mode via a PreToolUse `allow` decision, so they never dead-end when the tool isn't on `permissions.allow` (including under `skipAutoPermissionPrompt`); denies with an install/upgrade message if the CLI is missing or < 1.3.0 |
 | **Block CLI Workarounds** (`block-cli-workarounds.sh`) | PreToolUse (`Bash`) | Blocks direct CLI bypass of Very Good CLI commands through the Bash tool; exits 2 on failure (blocking) |
 | **Analyze** (`analyze.sh`) | PostToolUse (`Edit`/`Write`) | Runs `dart analyze` on the modified `.dart` file; exits 2 on failure (blocking — Claude must fix issues before continuing) |
 | **Format** (`format.sh`) | PostToolUse (`Edit`/`Write`) | Runs `dart format` on the modified `.dart` file; always exits 0 (non-blocking — formatting is applied silently) |

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -14,7 +14,7 @@
     ],
     "PreToolUse": [
       {
-        "matcher": "mcp__very-good-cli__.*",
+        "matcher": "mcp__.*very-good-cli__.*",
         "hooks": [
           {
             "type": "command",

--- a/hooks/scripts/check-vgv-cli.sh
+++ b/hooks/scripts/check-vgv-cli.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
-# PreToolUse hook: verify very_good_cli is installed before
-# allowing Very Good CLI MCP tool calls.
+# PreToolUse hook: gate Very Good CLI MCP tool calls.
+# When the CLI is installed and new enough, auto-approve the call so it is
+# always allowed regardless of run mode; otherwise deny with an install/
+# upgrade message instead of letting the call fail silently.
 
 if ! command -v jq &>/dev/null; then
   echo "jq is required for check-vgv-cli hook but not found" >&2
@@ -21,5 +23,7 @@ case "$cli_status" in
     ;;
 esac
 
-# Version OK
-exit 0
+# Version OK — auto-approve so the Very Good CLI MCP tool is always allowed,
+# even under skipAutoPermissionPrompt where a non-allowlisted tool would
+# otherwise fail closed and silently.
+allow "Very Good CLI >= ${MIN_VERSION} verified; auto-approving Very Good CLI MCP tool call."

--- a/hooks/scripts/vgv-cli-common.sh
+++ b/hooks/scripts/vgv-cli-common.sh
@@ -19,6 +19,23 @@ deny() {
   exit 0
 }
 
+# Auto-approve the tool call, skipping the interactive permission prompt.
+# A PreToolUse "allow" fires before the permission-mode check, so the call
+# proceeds in every run mode (interactive, headless, skipAutoPermissionPrompt).
+# Explicit deny/ask rules and managed deny lists still take precedence.
+allow() {
+  jq -n \
+    --arg reason "$1" \
+    '{
+      hookSpecificOutput: {
+        hookEventName: "PreToolUse",
+        permissionDecision: "allow",
+        permissionDecisionReason: $reason
+      }
+    }'
+  exit 0
+}
+
 # Check Very Good CLI availability and version.
 # Returns: "ok", "not_installed", or "outdated:<version>"
 check_vgv_cli() {


### PR DESCRIPTION
## Description

Fixes the silent dead-end from #109. When the `block-cli-workarounds` hook redirects the agent from `very_good create` (shell) to the `very-good-cli` MCP `create` tool, that tool has to be on `permissions.allow`. Under `skipAutoPermissionPrompt` a non-allowlisted MCP tool fails **closed and silently** — no dialog, no error — so scaffolding dead-ends with no visible reason. Plugins can't ship `permissions.allow` entries (no manifest field; plugin `settings.json` only supports `agent`/`subagentStatusLine`), so the fix uses the one runtime lever a plugin has: a PreToolUse hook decision.

`check-vgv-cli.sh` now returns a PreToolUse `allow` decision on success. PreToolUse hooks fire **before** the permission-mode check, so the call is approved in every run mode (interactive, headless, `skipAutoPermissionPrompt`, `bypassPermissions`) without the user editing `permissions.allow`. Only explicit deny/ask rules override an `allow` — none exist for these tools — so behavior is safe and predictable.

While here, this also fixes a latent matcher bug: the old matcher `mcp__very-good-cli__.*` never matched the plugin-namespaced tool name used on marketplace installs (`mcp__plugin_vgv-ai-flutter-plugin_very-good-cli__*`), so the guard was effectively dead for plugin users (related to #53). The matcher is broadened to `mcp__.*very-good-cli__.*`, which matches both the bare and plugin-namespaced forms.

### Changes

- `hooks/scripts/vgv-cli-common.sh` — add `allow()` helper (mirrors `deny()`).
- `hooks/scripts/check-vgv-cli.sh` — on success, `allow` the call instead of a silent `exit 0`.
- `hooks/hooks.json` — broaden PreToolUse matcher `mcp__very-good-cli__.*` → `mcp__.*very-good-cli__.*`.
- `README.md` + `CLAUDE.md` — update hook docs.

Missing/outdated CLI still denies with an install/upgrade message (a tool-usability guard, not a run-mode gate).

### Verification

- `allow` emitted on healthy CLI (1.3.0); `deny` on stubbed 1.2.0 and on not-installed.
- Matcher matches `mcp__very-good-cli__create` and `mcp__plugin_vgv-ai-flutter-plugin_very-good-cli__create`, skips `mcp__dart__*`.
- `bash -n` clean; `hooks.json` valid JSON.

Closes #109.

## Type of Change

- [ ] New feature (`feat`)
- [x] Bug fix (`fix`)
- [ ] Code refactor (`refactor`)
- [ ] Documentation (`docs`)
- [ ] CI change (`ci`)
- [ ] Chore (`chore`)
