### PR TITLE
feat: add argument-hint + $ARGUMENTS to sdk-upgrade and analysis-upgrade skills

### DIFF
--- a/skills/dart-flutter-sdk-upgrade/SKILL.md
+++ b/skills/dart-flutter-sdk-upgrade/SKILL.md
@@ -9,6 +9,7 @@ when_to_use: >
   Use when upgrading the Flutter or Dart SDK version in any VGV repository. Trigger on
   phrases like "bump Flutter to 3.x", "update SDK constraints", "upgrade Dart SDK",
   "update CI Flutter version", "bump SDK version", or "prep the SDK upgrade PR".
+argument-hint: "[flutter-version]"
 allowed-tools: Read Glob Grep Edit Write Bash
 model: sonnet
 effort: medium
@@ -46,9 +47,10 @@ for the target Flutter release before editing any files.
 2. Find the target Flutter stable release
 3. Note the Dart version listed alongside it
 
-If the user has not specified a Flutter version, look up the latest Flutter stable release
-from that same page. For pure Dart packages (no Flutter dependency), the Dart version is
-whatever the user specifies or the latest stable — no Flutter mapping needed.
+The target version comes from `$ARGUMENTS` (e.g. `3.41.0`) when the user supplied one. If
+`$ARGUMENTS` is empty, look up the latest Flutter stable release from that same page. For pure
+Dart packages (no Flutter dependency), the Dart version is whatever `$ARGUMENTS` specifies or
+the latest stable — no Flutter mapping needed.
 
 Confirm both resolved versions with the user before editing files.
 

--- a/skills/very-good-analysis-upgrade/SKILL.md
+++ b/skills/very-good-analysis-upgrade/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: very-good-analysis-upgrade
 description: Upgrade very_good_analysis lint package to new version across Dart/Flutter projects. Handles version bump, lint fixes, and PR creation.
+argument-hint: "[version]"
 allowed-tools: Read Glob Grep Bash
 model: sonnet
 effort: medium
@@ -29,8 +30,9 @@ These standards apply to every `very_good_analysis` upgrade.
 
 Confirm two things before proceeding:
 
-1. **Target version** — if the user didn't specify a version, fetch the latest from the pub.dev API
-   and use that. Don't ask — just look it up and proceed:
+1. **Target version** — use `$ARGUMENTS` as the target version when the user supplied one
+   (e.g. `10.0.0`). If `$ARGUMENTS` is empty, fetch the latest from the pub.dev API and use
+   that. Don't ask — just look it up and proceed:
 
     ```bash
     curl -s https://pub.dev/api/packages/very_good_analysis | jq -r '.latest.version'


### PR DESCRIPTION
## Description

Closes #113.

`dart-flutter-sdk-upgrade` and `very-good-analysis-upgrade` were the only two upgrade skills that could not take a version as an argument. This adds an `argument-hint` to each skill's frontmatter and threads `$ARGUMENTS` into the version-resolution step of each body, so an invoked version (e.g. `/very-good-analysis-upgrade 10.0.0`) is used as the target, with the existing "look up latest" behavior as the fallback when no argument is passed.

### Changes

- **`dart-flutter-sdk-upgrade`** — `argument-hint: "[flutter-version]"`; step 0 now resolves the target Flutter/Dart version from `$ARGUMENTS`, falling back to the latest stable when empty.
- **`very-good-analysis-upgrade`** — `argument-hint: "[version]"`; the "Before You Start" target-version step now reads `$ARGUMENTS`, falling back to the pub.dev latest when empty.

No README or `plugin.json` changes: the skills already exist in the skills table and Usage list, and the Usage list does not show argument hints for any other arg-taking skill (`/create-project`, `/testing`, `/accessibility`).

## Acceptance criteria

- [x] Both skills accept arguments with hints.

## Verification

- `markdownlint-cli2` (repo config): 0 errors
- `cspell` (repo config): 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)