### PR TITLE
fix: close the nine eval failures on main and unmask routing misses

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,6 +63,8 @@ skills/
   bloc/references/
   create-project/SKILL.md
   dart-flutter-sdk-upgrade/SKILL.md
+  dart-flutter-sdk-upgrade/references/
+    version-conflicts.md
   green-gate/SKILL.md
   green-gate/references/
     coverage.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,7 +110,8 @@ Every `SKILL.md` follows this structure:
 1. Create `skills/<skill_name>/SKILL.md` following the format above
 2. Create `evals/tests/<skill_name>.yaml` — eval cases with one prompt per major
    workflow the skill covers, a `skill-used` assertion on each, and one
-   `not-skill-used` negative control. Register the file under `tests:` in
+   `not-skill-used` negative control. Routing assertions carry `weight: 3` so a routing
+   miss cannot clear the per-case threshold. Register the file under `tests:` in
    `evals/promptfooconfig.yaml`. See `evals/README.md` for the format
 3. Update `keywords` **and** the `description` (marketplace text) in `.claude-plugin/plugin.json`
 4. Update the skills table in `README.md` (skill name must link to the `SKILL.md` file)

--- a/config/cspell.json
+++ b/config/cspell.json
@@ -43,6 +43,7 @@
     "promptfoo",
     "promptfooconfig",
     "pubspec",
+    "pubspecs",
     "redirections",
     "rubric",
     "serialization",

--- a/evals/README.md
+++ b/evals/README.md
@@ -8,32 +8,26 @@ npx promptfoo@latest eval -c evals/promptfooconfig.yaml
 ```
 
 Cases live in `evals/tests/<skill>.yaml` and run through
-[promptfoo](https://www.promptfoo.dev). They call real models, so they take minutes and
-consume usage. Run them locally before a PR that changes a skill. CI runs them after a
-merge, scoped to the changed skills, as an advisory signal, see [Running in CI](#running-in-ci).
+[promptfoo](https://www.promptfoo.dev). They call real models, so run them locally before
+a PR that changes a skill. CI runs them after a merge as an advisory signal, see
+[Running in CI](#running-in-ci).
 
 This file is the single source of truth. `README.md`, `CLAUDE.md` and `CONTRIBUTING.md`
-carry a few lines and a link here, so eval documentation belongs in this file rather
-than spread across them.
+link here rather than repeating any of it.
 
 ---
 
 ## Setup
 
-- **No API key.** Both the agent under test and the `llm-rubric` judge authenticate
-  through your local Claude Code session, so the suite runs on a subscription. The judge
-  is pinned to the same provider in `defaultTest.options`. Left unpinned, promptfoo picks
-  a grader from whatever key is in the environment, which is neither free nor
-  deterministic.
+- **No API key.** The agent under test and the `llm-rubric` judge both authenticate
+  through your local Claude Code session. The judge is pinned to that provider in
+  `defaultTest.options`. Unpinned, promptfoo grades with whatever key is in the
+  environment.
 - **The SDK must be in `node_modules` next to where you run promptfoo.** A `-g` install
-  does not work and neither does `NODE_PATH`, because promptfoo resolves it from the
-  working directory. `--no-save` keeps `package.json` out of the repo, and
-  `node_modules/` is already gitignored.
-- **Node `^20.20.0 || >=22.22.0`**, and `dart` on `PATH` for the `dart-parses` assertion.
-- **promptfoo behavior differs across releases**, so a suite that ran yesterday can
-  break on an upgrade with no change here. 0.120.0 failed to start at all. If a run dies
-  before any case executes, or the two columns stop differing, pin to the last version
-  you saw work and reconcile the config against the provider docs before editing a case.
+  does not work and neither does `NODE_PATH`.
+- **Node `^20.20.0 || >=22.22.0`**, and `dart` on `PATH` for `dart-parses`.
+- **Pin promptfoo if a run breaks with no change here.** Behavior differs across
+  releases and 0.120.0 failed to start at all.
 
 ---
 
@@ -41,50 +35,42 @@ than spread across them.
 
 promptfoo drives these through its
 [Claude Agent SDK provider](https://www.promptfoo.dev/docs/providers/claude-agent-sdk),
-which loads this repo as a local plugin and reports which skills the model actually
-invoked. Every case runs against both providers:
+which loads this repo as a local plugin and reports which skills the model invoked. Every
+case runs against both providers:
 
 | Provider          | Config                                                   | Measures                     |
 | ----------------- | -------------------------------------------------------- | ---------------------------- |
 | `with-skill`      | `plugins` points at this repo, `skills: all`, read tools | What the plugin produces     |
 | `sealed-baseline` | no `plugins`, `tools: []`                                | What the bare model produces |
 
-**A grader that passes in both columns is measuring the model, not the skill.** That is
-the number to read, and `npx promptfoo@latest view` gives the side-by-side. Exclude the
-negative controls when comparing columns, because a sealed model passes `not-skill-used`
-for free and counting those flatters the baseline.
+**A grader that passes in both columns is measuring the model, not the skill.** Exclude
+negative controls when comparing columns, since a sealed model passes `not-skill-used`
+for free.
 
 ### Sealing the baseline takes three keys
 
-None of these is the provider's default, and two are counter-intuitive enough that this
-suite shipped leaking until a real run exposed it:
+None is the provider's default, and this suite shipped leaking until a run exposed it:
 
-| Key                       | Why                                                                                                                                                                                                    |
-| ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `tools: []`               | `working_dir` is inside the checkout, so a baseline with read tools walks up to `../../skills`, reads `SKILL.md`, then passes rubrics on the answers. Observed via `Read`, `Grep` and `Bash`           |
-| `setting_sources: []`     | **Omitting the key loads everything**, including `CLAUDE.md`, which lists every skill. No tool call is involved, so no assertion can catch it. Both columns need it, or the ablation compares contexts |
-| `strict_mcp_config: true` | Without it, `--tools ""` still leaves every `mcp__*` tool in place                                                                                                                                     |
+| Key                       | Why                                                                                                          |
+| ------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| `tools: []`               | `working_dir` is inside the checkout, so read tools let the baseline walk to `../../skills` and read answers |
+| `setting_sources: []`     | Omitting it loads everything, including the `CLAUDE.md` that lists every skill. Both columns need it         |
+| `strict_mcp_config: true` | Without it, `--tools ""` still leaves every `mcp__*` tool in place                                           |
 
-Do not reach for `custom_allowed_tools` or `append_allowed_tools` to restrict a column.
-Those map to the SDK's `allowedTools`, which is an auto-approve list rather than an
-availability list, and an empty array is dropped entirely, silently restoring the full
-default tool set.
+Do not restrict a column with `custom_allowed_tools` or `append_allowed_tools`. Those map
+to `allowedTools`, an auto-approve list rather than an availability list, and an empty
+array is dropped entirely.
 
 ### Isolation is held by the config alone
 
-`skills` is a context filter, not a sandbox. Skill files stay on disk and readable
-through Read, Glob and Grep. The sealed baseline read `skills/bloc/SKILL.md` off disk on
-a stock run and then passed the rubric it should have failed.
+`skills` is a context filter, not a sandbox. Skill files stay on disk and readable, and
+the sealed baseline has read `skills/bloc/SKILL.md` off disk and then passed a rubric it
+should have failed.
 
-Nothing detects that automatically, and isolation has broken twice here by one of the
-three keys being loosened. Treat any change to `tools`, `working_dir`, `setting_sources`
-or `plugins` as invalidating every number measured before it, and re-baseline rather than
-comparing across the change. **The symptom to watch for is the sealed column climbing
-toward the plugin column.** That reads like the model improving and is almost always
-contamination.
-
-The direct check is that column's tool calls. A sealed run should make none, so any
-`Read` or `Grep` in it means the run had the answers and its score measures nothing.
+Treat any change to `tools`, `working_dir`, `setting_sources` or `plugins` as invalidating
+every number measured before it. Two checks: the sealed column should make **zero tool
+calls**, and it should not be climbing toward the plugin column. Climbing reads like the
+model improving and is almost always contamination.
 
 ---
 
@@ -112,103 +98,74 @@ The direct check is that column's tool calls. A sealed run should make none, so 
         verb, for example LoginSubmitted.
 ```
 
-### Threshold and routing weight
+A case passes at `defaultTest.threshold`, `0.8`, averaged across its assertions.
 
-`defaultTest.threshold` is `0.8`, so a case passes when its assertions average that or
-better. The threshold is per-case, so a weak case cannot hide behind strong siblings.
-
-**Every `skill-used` and `not-skill-used` assertion carries `weight: 3`**, so a routing
-miss cannot clear the threshold on its own. Unweighted it could: a six-assertion case
-whose only failure was `skill-used` averaged `0.83` and reported green, which is how a
-measured bloc routing failure went unnoticed for a whole run.
-
-Writing `n` for a case's non-routing assertions, which range from 1 to 8 here, a routing
-miss scores `n / (n + 3)`, at most `0.727`. Three is the smallest weight that holds for
-every case size, because a routing miss clears `0.8` whenever the weight is below
-`n / 4`. The cost is asymmetric and worth knowing: on the five cases with 7 or more
-content assertions, two content failures now score `0.818` to `0.900` and pass, where
-unweighted they failed. Raising the weight makes that worse rather than better, since
-routing then dominates the average. Restoring two-miss strictness on a large case is a
-per-case fix. The one-soft-miss tolerance holds for `n >= 2`. The two `n = 1` cases fail
-on a single content miss, as they did unweighted.
-
-Nothing enforces the weight on new cases automatically.
+**Routing carries `weight: 3`, so a routing miss alone sinks the case.** Unweighted it did
+not: a six-assertion case failing only `skill-used` averaged `0.83` and reported green.
+Three is the minimum that works across every case size here. It buys that by letting two
+content misses pass on the five largest cases, and raising it further makes that worse
+rather than better. Nothing applies the weight to new cases for you.
 
 ### Assertions
 
-| `type`                                     | Measures         | Notes                                                                                                                                               |
-| ------------------------------------------ | ---------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `skill-used` / `not-skill-used`            | process          | Reads `metadata.skillCalls`, derived from `Skill` tool calls. Errored skill attempts do not satisfy it. Always `weight: 3`                          |
-| `regex` / `not-regex`                      | style            | Any assertion negates with a `not-` prefix                                                                                                          |
-| `contains` / `icontains` / `not-icontains` | outcome          | Case-insensitive variants for one-word answers                                                                                                      |
-| `llm-rubric`                               | style            | Model-graded against a criterion                                                                                                                    |
-| `javascript`                               | outcome, process | `file://assertions/*.js`, resolved against the config file's directory even from a test file, or inline reading `context.providerResponse.metadata` |
+| `type`                                     | Measures         | Notes                                                                                         |
+| ------------------------------------------ | ---------------- | --------------------------------------------------------------------------------------------- |
+| `skill-used` / `not-skill-used`            | process          | Reads `metadata.skillCalls`. An errored skill attempt does not satisfy it. Always `weight: 3` |
+| `regex` / `not-regex`                      | style            | Any assertion negates with a `not-` prefix                                                    |
+| `contains` / `icontains` / `not-icontains` | outcome          | Case-insensitive variants for one-word answers                                                |
+| `llm-rubric`                               | style            | Model-graded against a criterion                                                              |
+| `javascript`                               | outcome, process | `file://assertions/*.js`, resolved against the config's directory even from a test file       |
 
-`evals/assertions/dart-parses.js` checks that every fenced ```` ```dart ```` block
-parses. It runs `dart format --output=none`, which parses without resolving, because
-snippets reference classes absent from the fixture and semantic analysis would fail
-every case. Each block is tried three ways before counting as a failure: as-is, wrapped
-in a function body for a bare statement, and wrapped as an expression for a widget tree
-pasted with no trailing semicolon. The third shape was added after a run failed three
-cases whose Dart was fine. It still rejects unbalanced parens, stray keywords and
-truncated classes.
+`dart-parses.js` checks that every fenced ```` ```dart ```` block parses. It runs
+`dart format --output=none` so nothing has to resolve, and tries each block three ways
+before failing it: as-is, as a statement, and as a bare expression. Keep all three, the
+last was added after a run failed three cases whose Dart was fine.
 
-**Rubrics are graded blind.** The judge sees the response text and the criterion, never
-the prompt. A criterion like "the response fixes the loop bound" is therefore
-unanswerable and fails at random: both columns once returned byte-identical correct
-output and the judge scored one `1.00` and the other `0.30`. Grade task success with a
-`regex` and keep rubrics to properties visible in the text alone.
+**Rubrics are graded blind**, on the response text and the criterion with no prompt. So
+"the response fixes the loop bound" is unanswerable and scores at random: identical
+output once scored `1.00` in one column and `0.30` in the other. Grade task success with
+a `regex` and keep rubrics to properties visible in the text alone.
 
 ### The fixture must stay neutral
 
-Both columns use `working_dir: ./fixture`, a bare Flutter app skeleton. An entirely
-empty directory is its own confound, because with no project in sight the model asks for
-the code instead of writing it and graders fail for unrelated reasons.
+Both columns use `working_dir: ./fixture`, a bare Flutter app skeleton. It cannot be
+empty, or the model asks for code instead of writing it. It also cannot hint at what a
+skill teaches: an earlier pubspec listed `bloc`, `flutter_bloc`, `equatable` and
+`mocktail`, and the sealed column inferred the conventions from the dependency list,
+collapsing bloc's measured lift from +10 points to +1. Keep it to what a new Flutter app
+ships with.
 
-An earlier version of that pubspec listed `bloc`, `flutter_bloc`, `equatable`, `mocktail`
-and `very_good_analysis`. The sealed column read the dependency list, inferred the
-conventions the skills exist to supply, and collapsed bloc's measured lift from +10
-points to +1. If anything in the fixture hints at what a skill teaches, it is handing the
-baseline the answers. Keep it to what a new Flutter app ships with.
-
-Prompts must be self-contained for the same reason. The fixture has no source in `lib/`,
-so a prompt about "my AuthService" earns a careful refusal. Paste the class into the
-prompt, and name pasted text as authoritative when the prompt describes state that is not
-on disk, or a run will go looking for it and answer about the empty fixture instead.
+Prompts must be self-contained for the same reason. Paste in any class the prompt refers
+to, and name pasted text as authoritative when it describes state not on disk, or a run
+will go looking and answer about the empty fixture instead.
 
 ### Routing is tested, not assumed
 
 Prompts name no skill. With `skills: all` the model routes on its own, and `skill-used`
-makes a routing failure legible as its own failed assertion instead of as unexplained
-content failures downstream. Every skill also has one negative control asserting
-`not-skill-used`, so a skill firing where it should not is caught rather than inferred.
+makes a routing failure legible instead of showing up as unexplained content failures.
+Every skill also has one negative control asserting `not-skill-used`.
 
-The slash-command path cannot be measured this way. Invoking a skill as `/<name>` expands
-its content into the prompt with no `Skill` tool call, so routing is only observable when
-the model chooses the skill itself.
+The slash-command path cannot be measured this way. `/<name>` expands the skill into the
+prompt with no `Skill` tool call, so routing is only observable when the model chooses.
 
 ### Checklist
 
 1. **Write the prompt as a user would send it**, with real phrasing and real ambiguity.
 2. **Make it self-contained.** Paste in any class it refers to.
-3. **Add `skill-used` at `weight: 3`.** The one exception is a prompt demanding a single
-   token, which does not justify a Skill round-trip and would measure the harness. Three
-   cases omit it and each says so in a comment. If you omit it, leave the comment.
-4. **Grade mechanically where you can**, a required import or a forbidden package, and
-   with `llm-rubric` where the property is structural.
+3. **Add `skill-used` at `weight: 3`.** Three cases omit it because they demand a single
+   token, and each says so in a comment. If you omit it, leave the comment.
+4. **Grade mechanically where you can**, and with `llm-rubric` where the property is
+   structural.
 5. **Only ask for what the prompt supplied.** A rubric wanting per-failure detail from a
-   prompt that gave none can never pass, and a rubric wanting prose will always fail a
-   prompt ending "Output Dart code only".
-6. **Include the cases where the skill must say no.** Ask for the anti-pattern outright
-   and grade that the response declines and offers the alternative. A skill earns its
-   keep on its prohibitions.
+   prompt that gave none can never pass.
+6. **Include the cases where the skill must say no.** A skill earns its keep on its
+   prohibitions.
 7. **Keep the negative control's rubric to the absence of the skill's vocabulary**, and
-   grade the task itself with a `regex`. A negative control whose rubric also asks "did
-   it do the task" hits the blind-judge trap above.
-8. **Write criteria a stranger could apply** from the response text alone, naming what
-   satisfies them and what does not.
-9. **Check it beats the baseline.** An assertion that passes in the sealed column too is
-   measuring Claude, not your skill. One case was dropped for scoring `1.00` in both.
+   grade the task with a `regex`. Asking a blind judge "did it do the task" is the trap
+   above.
+8. **Write criteria a stranger could apply** from the response text alone.
+9. **Check it beats the baseline.** An assertion that also passes sealed is measuring
+   Claude. One case was dropped for scoring `1.00` in both.
 
 ---
 
@@ -225,36 +182,31 @@ $P view                                                          # the side-by-s
 ```
 
 **Read the per-column split, not promptfoo's total.** The sealed column is meant to fail,
-so roughly a third of the 200 results failing is the healthy shape. Write the run to the
-gitignored `evals/.runs/`, then split it:
+so about a third of the 200 results failing is the healthy shape. Write runs to the
+gitignored `evals/.runs/`, then split:
 
 ```bash
 $P eval -c evals/promptfooconfig.yaml --no-table -o evals/.runs/latest.json
 node -e 'const r=require("./evals/.runs/latest.json"),c={};for(const x of r.results.results){const l=x.provider.label;c[l]??={n:0,pass:0};c[l].n++;c[l].pass+=x.success?1:0}console.table(c)'
 ```
 
-`node evals/ci-summary.js evals/.runs/latest.json` renders the same run as the per-skill
-table CI posts. It buckets errored results separately, so a skill whose cases errored
-reads as thin coverage rather than as failures.
+`node evals/ci-summary.js evals/.runs/latest.json` renders the per-skill table CI posts,
+bucketing errored results separately so an errored skill reads as thin coverage rather
+than failure.
 
-**One run is not a measurement.** These are non-deterministic and they are not a merge
-gate. Treat a single red case as a prompt to look, never as proof of a regression:
+**One run is not a measurement**, and these are not a merge gate.
 
-- `--no-cache` is required for fresh generations, since promptfoo caches by default.
-- `--repeat 3` before editing anything. Unedited cases have been measured moving between
-  runs, one across the pass/fail line, and cases drifting between 2/3 and 3/3 are this
-  suite's noise floor. Two skills were nearly "fixed" off single red reps that a repeat
-  run showed were noise.
-- A `529 Overloaded` scores 0 with no failing assertion, indistinguishable from a content
-  failure unless you check `res.error`. One full run hit 14 of them, and a long local run
-  hit 19 clustered in its final 12% as the session throttled. Follow up with
-  `--retry-errors` before believing a failure count.
+- `--no-cache` for fresh generations. promptfoo caches by default.
+- `--repeat 3` before editing anything. Unedited cases move between runs, and cases
+  drifting between 2/3 and 3/3 are this suite's noise floor. Two skills were nearly
+  "fixed" off single red reps that turned out to be noise.
+- A `529 Overloaded` scores 0 with no failing assertion, so it is indistinguishable from
+  a content failure unless you check `res.error`. Follow up with `--retry-errors`.
 - Variance in the plugin column is mostly routing rather than content.
 
-Budget roughly $0.10 to $0.20 and 10 to 30 seconds per case per provider, so a full
-two-column run of 100 cases lands near $20 to $40 of equivalent usage and well over half
-an hour. A 300-case `--repeat 3` run took 4h32m locally. Use `--filter-pattern` while
-iterating. A full run is a release-time check, not an edit-loop one.
+Budget roughly $0.10 to $0.20 and 10 to 30 seconds per case per provider. A full
+two-column run is a release-time check, not an edit-loop one, so use `--filter-pattern`
+while iterating.
 
 ---
 
@@ -269,67 +221,59 @@ request. Three choices keep the bill down, and each costs something:
 | Only the changed skills  | One skill is 6 or 7 cases out of 100                     | A change affecting routing globally can be missed                |
 | `with-skill` column only | Half of every run                                        | No ablation, so it cannot tell you a case stopped discriminating |
 
-Dropping the sealed column is the safe half of that. The baseline exists to prove a case
-*discriminates*, which you answer once when writing the case. Regression detection does
-not need it. Re-check it deliberately with the `include_baseline` input.
+Dropping the sealed column is the safe half. The baseline proves a case *discriminates*,
+which you answer once when writing it. Re-check deliberately with `include_baseline`.
 
-A change to `promptfooconfig.yaml`, `assertions/` or `fixture/` widens the scope to all
-15 skills, since any of them can affect every case.
+Changing `promptfooconfig.yaml`, `assertions/` or `fixture/` widens the scope to all 15
+skills, since any of them affects every case.
 
-Cost is bounded rather than estimated. `max_budget_usd` is enforced per case, so the
-ceiling is `cases × columns × max_budget_usd`: about **$3.50** for a one-skill merge at
-the current `0.5`, and **$100** for a full two-column run. Typical spend is far below
-that, but the ceiling is the number for a budget alarm, and a case that hits it errors
-rather than overspending.
+`max_budget_usd` is enforced per case, so cost is bounded rather than estimated:
+`cases × columns × max_budget_usd`, about **$3.50** for a one-skill merge and **$100**
+for a full two-column run. A case that hits the ceiling errors rather than overspending.
 
-Two differences from the local path:
+Two differences from local:
 
-- **It needs `ANTHROPIC_API_KEY`.** Locally both providers set `apiKeyRequired: false`
-  and use the Claude Code session, while CI has none. The workflow runs a one-case smoke
-  test first so an auth problem fails in seconds rather than after a full matrix.
-- **It is `continue-on-error`**, deliberately, for the variance reasons above. Confirm
-  anything red locally with `--repeat 3`.
+- **It needs `ANTHROPIC_API_KEY`**, since there is no Claude Code session. A one-case
+  smoke test runs first so auth fails in seconds rather than after a full matrix.
+- **It is `continue-on-error`**, deliberately, for the variance reasons above.
 
-The job has a one-hour ceiling. 100 cases in one column fits. A `--repeat 3` dispatch
-does not, and will be cancelled without writing an artifact. Shard by skill across
-parallel jobs if that mode is wanted. For a full run before a release, use the manual
-trigger with `scope: all-skills`.
+The job has a one-hour ceiling. 100 cases in one column fits, `--repeat 3` does not and
+will be cancelled without an artifact. Shard by skill if you want that mode. For a full
+run before a release, use the manual trigger with `scope: all-skills`.
 
 ---
 
 ## What these evals do not cover
 
-| Not covered                   | Why                                                                                                                                                                                                                                                                                        |
-| ----------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| **Judge calibration**         | Most assertions are `llm-rubric` with no human-labelled gold set and no measured agreement. Strong judges reach roughly 80% agreement with humans, and raw agreement can read 90% while a judge does nothing meaningful. Rubric verdicts are unverified until someone hand-labels a sample |
-| **Tool execution**            | No MCP servers are configured, so the six skills whose real job is calling tools or mutating files, `create-project`, `green-gate`, `license-compliance`, `ui-package`, `dart-flutter-sdk-upgrade` and `very-good-analysis-upgrade`, are graded only on the decisions they narrate         |
-| **Whether the code compiles** | `dart-parses` proves syntax only. Snippets reference classes absent from the fixture                                                                                                                                                                                                       |
-| **Judge independence**        | Generator and rubric grader are the same model family and may share blind spots                                                                                                                                                                                                            |
-| **Stable routing**            | Whether a skill activates is itself nondeterministic. One case routed 3 of 3 on one pass and failed to route on the next, taking every downstream assertion with it. This is why `skill-used` is its own assertion                                                                         |
-| **Prose in a `SKILL.md`**     | Deliberate. An earlier version asserted about a hundred `contains` patterns against skill bodies, so a copy-edit failed the gate while teaching the same thing                                                                                                                             |
-| **The skills' own surfaces**  | Nothing verifies that a name in `allowed-tools` still exists, that a markdown link to a reference resolves, or that `name` agrees with the directory. See below                                                                                                                            |
+| Not covered                   | Why                                                                                                                                          |
+| ----------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Judge calibration**         | Most assertions are `llm-rubric` with no human-labelled gold set. Raw agreement can read 90% while a judge does nothing meaningful           |
+| **Tool execution**            | No MCP servers are configured, so the six skills whose job is calling tools are graded only on the decisions they narrate                    |
+| **Whether the code compiles** | `dart-parses` proves syntax only                                                                                                             |
+| **Judge independence**        | Generator and grader are the same model family and may share blind spots                                                                     |
+| **Stable routing**            | Whether a skill activates is nondeterministic. One case routed 3 of 3 on one pass and not at all on the next, taking every assertion with it |
+| **Prose in a `SKILL.md`**     | Deliberate. An earlier version asserted a hundred `contains` patterns against skill bodies, so a copy-edit failed the gate                   |
+| **The skills' own surfaces**  | Nothing verifies that an `allowed-tools` name exists, that a reference link resolves, or that `name` matches the directory                   |
 
 `claude plugin validate .` does not cover the surfaces either. It was measured passing
-with a bogus tool name, a broken reference link, and a `name`/folder mismatch all in
-place at once. Four invariants are held by convention alone:
+with a bogus tool name, a broken reference link and a `name`/folder mismatch all at once.
+Four invariants are held by convention alone:
 
-- `create-project` must not declare `Bash`, because scaffolding goes through the Very
-  Good CLI MCP server and `block-cli-workarounds.sh` blocks the Bash path
-- `green-gate` must declare `Bash`, because the coverage gate parses
-  `coverage/lcov.info` and no MCP tool reads it
-- `.mcp.json` must keep `--enable dart_format`, because the Dart MCP server's `cli`
-  feature category is off by default
-- the `flutter-reviewer` agent must declare no `Edit`, `Write` or `NotebookEdit`, because
+- `create-project` must not declare `Bash`, since `block-cli-workarounds.sh` blocks that
+  path and scaffolding goes through the Very Good CLI MCP server
+- `green-gate` must declare `Bash`, since the coverage gate parses `coverage/lcov.info`
+  and no MCP tool reads it
+- `.mcp.json` must keep `--enable dart_format`, since the Dart MCP server's `cli` feature
+  category is off by default
+- the `flutter-reviewer` agent must declare no `Edit`, `Write` or `NotebookEdit`, since
   `tools` cannot scope Bash by command
 
-The failure mode to watch for is a Claude Code or MCP release renaming a tool. A skill
-still naming the old one breaks silently, and the six narration-graded skills are the
-weak spot: they describe the tool they would call, so a case asserting that description
-keeps passing after the tool ceases to exist. `green-gate` shipped exactly that bug,
-naming `mcp__dart__dart_format` while `.mcp.json` started the server without
-`--enable dart_format`. Note the shape of it. The tool existed the whole time, in a
-feature category the server disables by default, so checking that a tool exists
-somewhere is not the same as checking that this config exposes it.
+The failure mode to watch for is a release renaming a tool. The narration-graded skills
+describe the tool they would call, so a case asserting that description keeps passing
+after the tool stops being reachable. `green-gate` shipped that bug, naming
+`mcp__dart__dart_format` while `.mcp.json` started the server without
+`--enable dart_format`. A name can be correct and still unreachable, so checking that a
+tool exists is not checking that this config exposes it.
 
 ---
 

--- a/evals/README.md
+++ b/evals/README.md
@@ -50,13 +50,9 @@ invoked. Every case runs against both providers:
 | `sealed-baseline` | no `plugins`, `tools: []`                                | What the bare model produces |
 
 **A grader that passes in both columns is measuring the model, not the skill.** That is
-the number to read. `npx promptfoo@latest view` gives the side-by-side.
-
-Measured once as a full two-column run: 79/85 in the plugin column against 3/85 sealed,
-an 89-point lift, negative controls excluded because a sealed model passes
-`not-skill-used` for free. The sealed column made zero tool calls on that run, so
-isolation held. Two of those skills had no case changes at all and still moved, which is
-what separates skill work from case work in the totals.
+the number to read, and `npx promptfoo@latest view` gives the side-by-side. Exclude the
+negative controls when comparing columns, because a sealed model passes `not-skill-used`
+for free and counting those flatters the baseline.
 
 ### Sealing the baseline takes three keys
 
@@ -86,6 +82,9 @@ or `plugins` as invalidating every number measured before it, and re-baseline ra
 comparing across the change. **The symptom to watch for is the sealed column climbing
 toward the plugin column.** That reads like the model improving and is almost always
 contamination.
+
+The direct check is that column's tool calls. A sealed run should make none, so any
+`Read` or `Grep` in it means the run had the answers and its score measures nothing.
 
 ---
 

--- a/evals/README.md
+++ b/evals/README.md
@@ -112,11 +112,20 @@ is the number to read. Use `npx promptfoo@latest view` for the side-by-side.
 assertions average that or better. The threshold is per-case, so a weak case cannot
 hide behind strong siblings.
 
+**Routing carries `weight: 3`.** Every `skill-used` and `not-skill-used` assertion is
+weighted so a routing miss cannot clear the threshold on its own. Unweighted it could:
+a six-assertion case whose only failure was `skill-used` averaged `0.83` and reported
+green, which is how a measured bloc routing failure went unnoticed for a whole run. At
+weight 3 a routing miss with every content assertion passing scores `n / (n + 3)` — at
+most `0.75` for the case sizes here — while a single content miss with routing intact
+still clears, so the deliberate one-soft-miss tolerance survives. Keep the weight on
+routing assertions in new cases; nothing enforces it automatically.
+
 ### Assertions
 
 | `type` | Measures | Notes |
 | ------ | -------- | ----- |
-| `skill-used` / `not-skill-used` | process | Reads `metadata.skillCalls`, which promptfoo derives from `Skill` tool calls. Errored skill attempts do not satisfy it |
+| `skill-used` / `not-skill-used` | process | Reads `metadata.skillCalls`, which promptfoo derives from `Skill` tool calls. Errored skill attempts do not satisfy it. Always `weight: 3` — see the threshold note above |
 | `regex` / `not-regex` | style | Any assertion negates with a `not-` prefix |
 | `contains` / `icontains` / `not-icontains` | outcome | Case-insensitive variants for one-word answers |
 | `llm-rubric` | style | Model-graded against a criterion |

--- a/evals/README.md
+++ b/evals/README.md
@@ -1,55 +1,35 @@
 # Skill Evals
 
-One question: does Claude route to the skill, and does the output follow it?
+Does Claude route to the skill, and does the output follow it? Cases live in
+`evals/tests/<skill>.yaml` and run through [promptfoo](https://www.promptfoo.dev)
+against real models.
 
 ```bash
 npm install --no-save @anthropic-ai/claude-agent-sdk   # from the repo root, once
 npx promptfoo@latest eval -c evals/promptfooconfig.yaml
 ```
 
-Cases live in `evals/tests/<skill>.yaml` and run through
-[promptfoo](https://www.promptfoo.dev). They call real models, so run them locally before
-a PR that changes a skill. CI runs them after a merge as an advisory signal, see
-[Running in CI](#running-in-ci).
-
-This file is the single source of truth. `README.md`, `CLAUDE.md` and `CONTRIBUTING.md`
-link here rather than repeating any of it.
-
----
-
-## Setup
-
-- **No API key.** The agent under test and the `llm-rubric` judge both authenticate
-  through your local Claude Code session. The judge is pinned to that provider in
-  `defaultTest.options`. Unpinned, promptfoo grades with whatever key is in the
-  environment.
-- **The SDK must be in `node_modules` next to where you run promptfoo.** A `-g` install
-  does not work and neither does `NODE_PATH`.
-- **Node `^20.20.0 || >=22.22.0`**, and `dart` on `PATH` for `dart-parses`.
-- **Pin promptfoo if a run breaks with no change here.** Behavior differs across
-  releases and 0.120.0 failed to start at all.
+- The SDK must sit in `node_modules` next to where you run promptfoo. `-g` and
+  `NODE_PATH` do not work.
+- Node `^20.20.0 || >=22.22.0`, and `dart` on `PATH` for `dart-parses`.
+- No API key. Agent and judge both use your Claude Code session. The judge is pinned in
+  `defaultTest.options`, and unpinned it grades with whatever key is in the environment.
+- Pin promptfoo if a run breaks with no change here. 0.120.0 failed to start at all.
 
 ---
 
-## How it works
-
-promptfoo drives these through its
-[Claude Agent SDK provider](https://www.promptfoo.dev/docs/providers/claude-agent-sdk),
-which loads this repo as a local plugin and reports which skills the model invoked. Every
-case runs against both providers:
+## The two columns
 
 | Provider          | Config                                                   | Measures                     |
 | ----------------- | -------------------------------------------------------- | ---------------------------- |
 | `with-skill`      | `plugins` points at this repo, `skills: all`, read tools | What the plugin produces     |
 | `sealed-baseline` | no `plugins`, `tools: []`                                | What the bare model produces |
 
-**A grader that passes in both columns is measuring the model, not the skill.** Exclude
-negative controls when comparing columns, since a sealed model passes `not-skill-used`
-for free.
+A grader that passes in both is measuring the model, not the skill. Exclude negative
+controls when comparing, since a sealed model passes `not-skill-used` for free.
 
-### Sealing the baseline takes three keys
-
-None is the provider's default, and this suite shipped leaking until a run exposed it:
+**Sealing the baseline takes three keys, and this suite shipped leaking until a run
+exposed it.** None is the provider's default:
 
 | Key                       | Why                                                                                                          |
 | ------------------------- | ------------------------------------------------------------------------------------------------------------ |
@@ -61,22 +41,16 @@ Do not restrict a column with `custom_allowed_tools` or `append_allowed_tools`. 
 to `allowedTools`, an auto-approve list rather than an availability list, and an empty
 array is dropped entirely.
 
-### Isolation is held by the config alone
-
-`skills` is a context filter, not a sandbox. Skill files stay on disk and readable, and
-the sealed baseline has read `skills/bloc/SKILL.md` off disk and then passed a rubric it
-should have failed.
-
-Treat any change to `tools`, `working_dir`, `setting_sources` or `plugins` as invalidating
-every number measured before it. Two checks: the sealed column should make **zero tool
-calls**, and it should not be climbing toward the plugin column. Climbing reads like the
-model improving and is almost always contamination.
+`skills` is a context filter, not a sandbox: skill files stay readable on disk, and the
+sealed baseline has read `skills/bloc/SKILL.md` and then passed a rubric it should have
+failed. Treat any change to `tools`, `working_dir`, `setting_sources` or `plugins` as
+invalidating earlier numbers. The sealed column should make **zero tool calls** and should
+not be climbing toward the plugin column, which reads like the model improving and is
+almost always contamination.
 
 ---
 
 ## Writing a case
-
-`evals/tests/<skill>.yaml` is a list of promptfoo tests:
 
 ```yaml
 - description: bloc-writes-sealed-events-and-states
@@ -98,191 +72,112 @@ model improving and is almost always contamination.
         verb, for example LoginSubmitted.
 ```
 
-A case passes at `defaultTest.threshold`, `0.8`, averaged across its assertions.
+A case passes at `threshold: 0.8`, averaged across its assertions. **Routing carries
+`weight: 3` so a routing miss alone sinks the case**, which unweighted it did not. Three is
+the minimum that works across every case size, at the cost of letting two content misses
+pass on the five largest cases. Nothing applies the weight for you.
 
-**Routing carries `weight: 3`, so a routing miss alone sinks the case.** Unweighted it did
-not: a six-assertion case failing only `skill-used` averaged `0.83` and reported green.
-Three is the minimum that works across every case size here. It buys that by letting two
-content misses pass on the five largest cases, and raising it further makes that worse
-rather than better. Nothing applies the weight to new cases for you.
+| `type`                                     | Notes                                                                                         |
+| ------------------------------------------ | --------------------------------------------------------------------------------------------- |
+| `skill-used` / `not-skill-used`            | Reads `metadata.skillCalls`. An errored skill attempt does not satisfy it. Always `weight: 3` |
+| `regex` / `not-regex`                      | Any assertion negates with a `not-` prefix                                                    |
+| `contains` / `icontains` / `not-icontains` | Case-insensitive variants for one-word answers                                                |
+| `llm-rubric`                               | Model-graded against a criterion                                                              |
+| `javascript`                               | `file://assertions/*.js`, resolved against the config's directory even from a test file       |
 
-### Assertions
+Four traps, each of which has already cost a false result here:
 
-| `type`                                     | Measures         | Notes                                                                                         |
-| ------------------------------------------ | ---------------- | --------------------------------------------------------------------------------------------- |
-| `skill-used` / `not-skill-used`            | process          | Reads `metadata.skillCalls`. An errored skill attempt does not satisfy it. Always `weight: 3` |
-| `regex` / `not-regex`                      | style            | Any assertion negates with a `not-` prefix                                                    |
-| `contains` / `icontains` / `not-icontains` | outcome          | Case-insensitive variants for one-word answers                                                |
-| `llm-rubric`                               | style            | Model-graded against a criterion                                                              |
-| `javascript`                               | outcome, process | `file://assertions/*.js`, resolved against the config's directory even from a test file       |
+- **Rubrics are graded blind**, on the response text and criterion with no prompt. So "the
+  response fixes the loop bound" scores at random: identical output once got `1.00` and
+  `0.30`. Grade task success with a `regex`.
+- **Only ask for what the prompt supplied.** A rubric wanting per-failure detail from a
+  prompt that gave none can never pass.
+- **The fixture must stay neutral.** It cannot be empty, or the model asks for code instead
+  of writing it. It cannot hint at what a skill teaches either: an earlier pubspec listed
+  `bloc`, `flutter_bloc`, `equatable` and `mocktail`, and the sealed column inferred the
+  conventions from it, collapsing bloc's measured lift from +10 points to +1.
+- **Prompts must be self-contained.** Paste in any class they refer to, and name pasted
+  text as authoritative when it describes state not on disk, or a run goes looking and
+  answers about the empty fixture.
 
-`dart-parses.js` checks that every fenced ```` ```dart ```` block parses. It runs
-`dart format --output=none` so nothing has to resolve, and tries each block three ways
-before failing it: as-is, as a statement, and as a bare expression. Keep all three, the
-last was added after a run failed three cases whose Dart was fine.
+Prompts name no skill, so `skill-used` is a real routing test, and every skill carries one
+negative control asserting `not-skill-used`. The `/<name>` path cannot be measured, since
+it expands the skill into the prompt with no `Skill` tool call.
 
-**Rubrics are graded blind**, on the response text and the criterion with no prompt. So
-"the response fixes the loop bound" is unanswerable and scores at random: identical
-output once scored `1.00` in one column and `0.30` in the other. Grade task success with
-a `regex` and keep rubrics to properties visible in the text alone.
-
-### The fixture must stay neutral
-
-Both columns use `working_dir: ./fixture`, a bare Flutter app skeleton. It cannot be
-empty, or the model asks for code instead of writing it. It also cannot hint at what a
-skill teaches: an earlier pubspec listed `bloc`, `flutter_bloc`, `equatable` and
-`mocktail`, and the sealed column inferred the conventions from the dependency list,
-collapsing bloc's measured lift from +10 points to +1. Keep it to what a new Flutter app
-ships with.
-
-Prompts must be self-contained for the same reason. Paste in any class the prompt refers
-to, and name pasted text as authoritative when it describes state not on disk, or a run
-will go looking and answer about the empty fixture instead.
-
-### Routing is tested, not assumed
-
-Prompts name no skill. With `skills: all` the model routes on its own, and `skill-used`
-makes a routing failure legible instead of showing up as unexplained content failures.
-Every skill also has one negative control asserting `not-skill-used`.
-
-The slash-command path cannot be measured this way. `/<name>` expands the skill into the
-prompt with no `Skill` tool call, so routing is only observable when the model chooses.
-
-### Checklist
-
-1. **Write the prompt as a user would send it**, with real phrasing and real ambiguity.
-2. **Make it self-contained.** Paste in any class it refers to.
-3. **Add `skill-used` at `weight: 3`.** Three cases omit it because they demand a single
-   token, and each says so in a comment. If you omit it, leave the comment.
-4. **Grade mechanically where you can**, and with `llm-rubric` where the property is
-   structural.
-5. **Only ask for what the prompt supplied.** A rubric wanting per-failure detail from a
-   prompt that gave none can never pass.
-6. **Include the cases where the skill must say no.** A skill earns its keep on its
-   prohibitions.
-7. **Keep the negative control's rubric to the absence of the skill's vocabulary**, and
-   grade the task with a `regex`. Asking a blind judge "did it do the task" is the trap
-   above.
-8. **Write criteria a stranger could apply** from the response text alone.
-9. **Check it beats the baseline.** An assertion that also passes sealed is measuring
-   Claude. One case was dropped for scoring `1.00` in both.
+Beyond that: write prompts as a user would send them, grade mechanically where you can,
+include the cases where the skill must say no, keep a negative control's rubric to the
+absence of the skill's vocabulary, and check an assertion fails in the sealed column before
+trusting it.
 
 ---
 
-## Running the suite
+## Running
 
 ```bash
 P="npx promptfoo@latest"
-$P eval -c evals/promptfooconfig.yaml                            # all 100, both columns
-$P eval -c evals/promptfooconfig.yaml --filter-pattern bloc      # one skill
+$P eval -c evals/promptfooconfig.yaml                          # all 100, both columns
+$P eval -c evals/promptfooconfig.yaml --filter-pattern bloc    # one skill
 $P eval -c evals/promptfooconfig.yaml --filter-providers with-skill
-$P eval -c evals/promptfooconfig.yaml --repeat 3 --no-cache      # is a red case real?
-$P eval -c evals/promptfooconfig.yaml --retry-errors             # re-run 529s only
-$P view                                                          # the side-by-side
+$P eval -c evals/promptfooconfig.yaml --repeat 3 --no-cache    # is a red case real?
+$P eval -c evals/promptfooconfig.yaml --retry-errors           # re-run 529s only
+$P view                                                        # the side-by-side
 ```
 
-**Read the per-column split, not promptfoo's total.** The sealed column is meant to fail,
-so about a third of the 200 results failing is the healthy shape. Write runs to the
-gitignored `evals/.runs/`, then split:
-
-```bash
-$P eval -c evals/promptfooconfig.yaml --no-table -o evals/.runs/latest.json
-node -e 'const r=require("./evals/.runs/latest.json"),c={};for(const x of r.results.results){const l=x.provider.label;c[l]??={n:0,pass:0};c[l].n++;c[l].pass+=x.success?1:0}console.table(c)'
-```
-
-`node evals/ci-summary.js evals/.runs/latest.json` renders the per-skill table CI posts,
-bucketing errored results separately so an errored skill reads as thin coverage rather
-than failure.
+Read the per-column split, not the total: the sealed column is meant to fail, so about a
+third of 200 results failing is healthy. Write runs to the gitignored `evals/.runs/` and
+render them with `node evals/ci-summary.js evals/.runs/latest.json`, which buckets errored
+results separately so an errored skill reads as thin coverage rather than failure.
 
 **One run is not a measurement**, and these are not a merge gate.
 
 - `--no-cache` for fresh generations. promptfoo caches by default.
-- `--repeat 3` before editing anything. Unedited cases move between runs, and cases
-  drifting between 2/3 and 3/3 are this suite's noise floor. Two skills were nearly
-  "fixed" off single red reps that turned out to be noise.
-- A `529 Overloaded` scores 0 with no failing assertion, so it is indistinguishable from
-  a content failure unless you check `res.error`. Follow up with `--retry-errors`.
-- Variance in the plugin column is mostly routing rather than content.
+- `--repeat 3` before editing anything. Cases drift between 2/3 and 3/3 on their own, and
+  two skills were nearly "fixed" off single red reps that turned out to be noise.
+- A `529 Overloaded` scores 0 with no failing assertion, indistinguishable from a content
+  failure unless you check `res.error`. Follow up with `--retry-errors`.
 
-Budget roughly $0.10 to $0.20 and 10 to 30 seconds per case per provider. A full
-two-column run is a release-time check, not an edit-loop one, so use `--filter-pattern`
-while iterating.
+Budget roughly $0.10 to $0.20 and 10 to 30 seconds per case per provider, so a full
+two-column run is a release check rather than an edit-loop one.
 
 ---
 
 ## Running in CI
 
-`.github/workflows/evals.yaml` runs these **after a merge to `main`**, never on a pull
-request. Three choices keep the bill down, and each costs something:
+`.github/workflows/evals.yaml` runs after a merge to `main`, never on a pull request,
+scoped to the changed skills, `with-skill` only, and `continue-on-error`. Each of those
+saves money and costs coverage: a regression is reported after it lands, a change that
+affects routing globally can be missed, and without the sealed column a case that has
+stopped discriminating goes unnoticed. Re-check that deliberately with `include_baseline`.
 
-| Choice                   | Saves                                                    | Costs                                                            |
-| ------------------------ | -------------------------------------------------------- | ---------------------------------------------------------------- |
-| Post-merge, not per-PR   | A PR is pushed to many times, `main` is merged into once | A regression is reported after it lands                          |
-| Only the changed skills  | One skill is 6 or 7 cases out of 100                     | A change affecting routing globally can be missed                |
-| `with-skill` column only | Half of every run                                        | No ablation, so it cannot tell you a case stopped discriminating |
-
-Dropping the sealed column is the safe half. The baseline proves a case *discriminates*,
-which you answer once when writing it. Re-check deliberately with `include_baseline`.
-
-Changing `promptfooconfig.yaml`, `assertions/` or `fixture/` widens the scope to all 15
-skills, since any of them affects every case.
-
-`max_budget_usd` is enforced per case, so cost is bounded rather than estimated:
-`cases × columns × max_budget_usd`, about **$3.50** for a one-skill merge and **$100**
-for a full two-column run. A case that hits the ceiling errors rather than overspending.
-
-Two differences from local:
-
-- **It needs `ANTHROPIC_API_KEY`**, since there is no Claude Code session. A one-case
-  smoke test runs first so auth fails in seconds rather than after a full matrix.
-- **It is `continue-on-error`**, deliberately, for the variance reasons above.
-
-The job has a one-hour ceiling. 100 cases in one column fits, `--repeat 3` does not and
-will be cancelled without an artifact. Shard by skill if you want that mode. For a full
-run before a release, use the manual trigger with `scope: all-skills`.
+- Changing `promptfooconfig.yaml`, `assertions/` or `fixture/` widens the scope to all 15
+  skills, since any of them affects every case.
+- CI needs `ANTHROPIC_API_KEY`, having no Claude Code session. A one-case smoke test runs
+  first so auth fails in seconds rather than after a full matrix.
+- `max_budget_usd` bounds cost per case, so the ceiling is `cases × columns × budget`:
+  about $3.50 for a one-skill merge, $100 for a full two-column run.
+- The job has a one-hour ceiling. 100 cases in one column fits, `--repeat 3` does not and
+  is cancelled without an artifact. For a full run, use the manual trigger with
+  `scope: all-skills`.
 
 ---
 
-## What these evals do not cover
+## What this does not cover
 
-| Not covered                   | Why                                                                                                                                          |
-| ----------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Judge calibration**         | Most assertions are `llm-rubric` with no human-labelled gold set. Raw agreement can read 90% while a judge does nothing meaningful           |
-| **Tool execution**            | No MCP servers are configured, so the six skills whose job is calling tools are graded only on the decisions they narrate                    |
-| **Whether the code compiles** | `dart-parses` proves syntax only                                                                                                             |
-| **Judge independence**        | Generator and grader are the same model family and may share blind spots                                                                     |
-| **Stable routing**            | Whether a skill activates is nondeterministic. One case routed 3 of 3 on one pass and not at all on the next, taking every assertion with it |
-| **Prose in a `SKILL.md`**     | Deliberate. An earlier version asserted a hundred `contains` patterns against skill bodies, so a copy-edit failed the gate                   |
-| **The skills' own surfaces**  | Nothing verifies that an `allowed-tools` name exists, that a reference link resolves, or that `name` matches the directory                   |
-
-`claude plugin validate .` does not cover the surfaces either. It was measured passing
-with a bogus tool name, a broken reference link and a `name`/folder mismatch all at once.
-Four invariants are held by convention alone:
-
-- `create-project` must not declare `Bash`, since `block-cli-workarounds.sh` blocks that
-  path and scaffolding goes through the Very Good CLI MCP server
-- `green-gate` must declare `Bash`, since the coverage gate parses `coverage/lcov.info`
-  and no MCP tool reads it
-- `.mcp.json` must keep `--enable dart_format`, since the Dart MCP server's `cli` feature
-  category is off by default
-- the `flutter-reviewer` agent must declare no `Edit`, `Write` or `NotebookEdit`, since
-  `tools` cannot scope Bash by command
-
-The failure mode to watch for is a release renaming a tool. The narration-graded skills
-describe the tool they would call, so a case asserting that description keeps passing
-after the tool stops being reachable. `green-gate` shipped that bug, naming
-`mcp__dart__dart_format` while `.mcp.json` started the server without
-`--enable dart_format`. A name can be correct and still unreachable, so checking that a
-tool exists is not checking that this config exposes it.
-
----
-
-## When to update what
-
-| You changed                | Do this                                                       |
-| -------------------------- | ------------------------------------------------------------- |
-| Added a skill              | Add `evals/tests/<skill>.yaml` and register it under `tests:` |
-| What a skill teaches       | Run its cases and update any that asserted the old behavior   |
-| A skill's reference layout | Update every markdown link to the moved file by hand          |
-| A skill's `allowed-tools`  | Confirm by hand that every name still exists                  |
-| `promptfooconfig.yaml`     | Re-baseline. Earlier numbers are not comparable across it     |
+- **Judge calibration.** Most assertions are `llm-rubric` with no human-labelled gold set.
+- **Tool execution.** No MCP servers are configured, so the six tool-driven skills are
+  graded only on the decisions they narrate.
+- **Compilation.** `dart-parses` proves syntax only, via `dart format --output=none` so
+  nothing has to resolve. It tries each block as-is, as a statement, and as a bare
+  expression before failing it. Keep all three shapes.
+- **Stable routing.** Whether a skill activates is nondeterministic, which is why
+  `skill-used` is its own assertion rather than inferred from content.
+- **Prose in a `SKILL.md`.** Deliberate. An earlier version asserted a hundred `contains`
+  patterns against skill bodies, so a copy-edit failed the gate.
+- **The skills' own surfaces.** Nothing checks that an `allowed-tools` name exists, that a
+  reference link resolves, or that `name` matches the directory. `claude plugin validate .`
+  was measured passing with a bogus tool name, a broken link and a `name`/folder mismatch
+  all at once. Four invariants are convention alone: `create-project` must not declare
+  `Bash`, `green-gate` must declare it for parsing `coverage/lcov.info`, `.mcp.json` must
+  keep `--enable dart_format`, and `flutter-reviewer` must declare no write tools. A tool
+  name can be correct and still unreachable, so a rename breaks the narration-graded skills
+  silently.

--- a/evals/README.md
+++ b/evals/README.md
@@ -3,18 +3,37 @@
 One question: does Claude route to the skill, and does the output follow it?
 
 ```bash
+npm install --no-save @anthropic-ai/claude-agent-sdk   # from the repo root, once
 npx promptfoo@latest eval -c evals/promptfooconfig.yaml
 ```
 
-Cases live in `evals/tests/*.yaml` and run through
-[promptfoo](https://www.promptfoo.dev). They call real models, so they take minutes
-and consume usage. Run them locally before a PR that changes a skill; CI runs them
-after a merge, scoped to the changed skills, as an advisory signal — see
-[Running in CI](#running-in-ci).
+Cases live in `evals/tests/<skill>.yaml` and run through
+[promptfoo](https://www.promptfoo.dev). They call real models, so they take minutes and
+consume usage. Run them locally before a PR that changes a skill. CI runs them after a
+merge, scoped to the changed skills, as an advisory signal, see [Running in CI](#running-in-ci).
 
-This file is the single source of truth. `README.md`, `CLAUDE.md` and
-`CONTRIBUTING.md` carry a few lines and a link here, so eval documentation belongs in
-this file rather than spread across them.
+This file is the single source of truth. `README.md`, `CLAUDE.md` and `CONTRIBUTING.md`
+carry a few lines and a link here, so eval documentation belongs in this file rather
+than spread across them.
+
+---
+
+## Setup
+
+- **No API key.** Both the agent under test and the `llm-rubric` judge authenticate
+  through your local Claude Code session, so the suite runs on a subscription. The judge
+  is pinned to the same provider in `defaultTest.options`. Left unpinned, promptfoo picks
+  a grader from whatever key is in the environment, which is neither free nor
+  deterministic.
+- **The SDK must be in `node_modules` next to where you run promptfoo.** A `-g` install
+  does not work and neither does `NODE_PATH`, because promptfoo resolves it from the
+  working directory. `--no-save` keeps `package.json` out of the repo, and
+  `node_modules/` is already gitignored.
+- **Node `^20.20.0 || >=22.22.0`**, and `dart` on `PATH` for the `dart-parses` assertion.
+- **promptfoo behavior differs across releases**, so a suite that ran yesterday can
+  break on an upgrade with no change here. 0.120.0 failed to start at all. If a run dies
+  before any case executes, or the two columns stop differing, pin to the last version
+  you saw work and reconcile the config against the provider docs before editing a case.
 
 ---
 
@@ -23,67 +42,54 @@ this file rather than spread across them.
 promptfoo drives these through its
 [Claude Agent SDK provider](https://www.promptfoo.dev/docs/providers/claude-agent-sdk),
 which loads this repo as a local plugin and reports which skills the model actually
-invoked. Everything lives in `evals/promptfooconfig.yaml` plus one YAML file of cases
-per skill under `evals/tests/`.
+invoked. Every case runs against both providers:
 
-**No API key.** Both the agent under test and the `llm-rubric` judge run through the
-Claude Agent SDK, which authenticates with your local Claude Code session, so the
-whole suite runs on a subscription. The judge is pinned to the same provider in
-`defaultTest.options`; left unpinned, promptfoo picks a grader from whatever key
-happens to be in the environment, which is neither free nor deterministic.
+| Provider          | Config                                                   | Measures                     |
+| ----------------- | -------------------------------------------------------- | ---------------------------- |
+| `with-skill`      | `plugins` points at this repo, `skills: all`, read tools | What the plugin produces     |
+| `sealed-baseline` | no `plugins`, `tools: []`                                | What the bare model produces |
 
-Two prerequisites:
+**A grader that passes in both columns is measuring the model, not the skill.** That is
+the number to read. `npx promptfoo@latest view` gives the side-by-side.
 
-```bash
-npm install --no-save @anthropic-ai/claude-agent-sdk   # from the repo root
-npx promptfoo@latest eval -c evals/promptfooconfig.yaml
-```
-
-- **The SDK must live in `node_modules` next to where you run promptfoo.** A `-g`
-  install does not work and neither does `NODE_PATH` — promptfoo resolves the SDK
-  from the working directory. `--no-save` keeps `package.json` and a lockfile out of
-  this repo; `node_modules/` is already gitignored.
-- **Node `^20.20.0 || >=22.22.0`**. `dart` also has to be on PATH for the
-  `dart_parses` assertion.
-
-Behavior differs across promptfoo releases, so a suite that ran yesterday can break on
-an upgrade with no change here. 0.120.0 failed to start at all. If a run dies before any
-case executes, or the two columns stop differing, pin to the last version you saw work
-and reconcile the config against the provider docs before editing a case.
-
-### The two columns are the ablation
-
-Every case runs against both providers:
-
-| Provider | Config | Measures |
-| -------- | ------ | -------- |
-| `with-skill` | `plugins` points at this repo, `skills: all`, read tools | What the plugin produces |
-| `sealed-baseline` | no `plugins`, `tools: []` | What the bare model produces |
+Measured once as a full two-column run: 79/85 in the plugin column against 3/85 sealed,
+an 89-point lift, negative controls excluded because a sealed model passes
+`not-skill-used` for free. The sealed column made zero tool calls on that run, so
+isolation held. Two of those skills had no case changes at all and still moved, which is
+what separates skill work from case work in the totals.
 
 ### Sealing the baseline takes three keys
 
-Nothing here is the provider's default, and two of them are counter-intuitive
-enough that this suite shipped leaking until a real run exposed it:
+None of these is the provider's default, and two are counter-intuitive enough that this
+suite shipped leaking until a real run exposed it:
 
-| Key | Why |
-| --- | --- |
-| `tools: []` | `working_dir` is inside the checkout, so a baseline with read tools walks up to `../../skills` and reads `SKILL.md` — then passes rubrics on the answers. Observed via `Read`, `Grep` and `Bash`. This emits `--tools ""`, removing all built-ins |
-| `setting_sources: []` | **Omitting the key loads everything**, including `CLAUDE.md`, which lists every skill. No tool call is involved, so no assertion can catch it |
-| `strict_mcp_config: true` | Without it, `--tools ""` still leaves every `mcp__*` tool in place |
+| Key                       | Why                                                                                                                                                                                                    |
+| ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `tools: []`               | `working_dir` is inside the checkout, so a baseline with read tools walks up to `../../skills`, reads `SKILL.md`, then passes rubrics on the answers. Observed via `Read`, `Grep` and `Bash`           |
+| `setting_sources: []`     | **Omitting the key loads everything**, including `CLAUDE.md`, which lists every skill. No tool call is involved, so no assertion can catch it. Both columns need it, or the ablation compares contexts |
+| `strict_mcp_config: true` | Without it, `--tools ""` still leaves every `mcp__*` tool in place                                                                                                                                     |
 
-Do not reach for `custom_allowed_tools` or `append_allowed_tools` to restrict a
-column. Those map to the SDK's `allowedTools`, which is an auto-approve list, not
-an availability list — the SDK's own docs say to use `tools` for that, and an empty
-array is dropped entirely, silently restoring the full default tool set.
+Do not reach for `custom_allowed_tools` or `append_allowed_tools` to restrict a column.
+Those map to the SDK's `allowedTools`, which is an auto-approve list rather than an
+availability list, and an empty array is dropped entirely, silently restoring the full
+default tool set.
 
-Both columns carry `setting_sources: []`. If only one does, the ablation compares
-contexts rather than the plugin. Plugins load through `--plugin-dir`, so `skills:
-all` still works with settings disabled.
+### Isolation is held by the config alone
 
-**A grader that passes in both columns is measuring the model, not the skill.** That
-is the number to read. Use `npx promptfoo@latest view` for the side-by-side.
+`skills` is a context filter, not a sandbox. Skill files stay on disk and readable
+through Read, Glob and Grep. The sealed baseline read `skills/bloc/SKILL.md` off disk on
+a stock run and then passed the rubric it should have failed.
 
-### Case format
+Nothing detects that automatically, and isolation has broken twice here by one of the
+three keys being loosened. Treat any change to `tools`, `working_dir`, `setting_sources`
+or `plugins` as invalidating every number measured before it, and re-baseline rather than
+comparing across the change. **The symptom to watch for is the sealed column climbing
+toward the plugin column.** That reads like the model improving and is almost always
+contamination.
+
+---
+
+## Writing a case
 
 `evals/tests/<skill>.yaml` is a list of promptfoo tests:
 
@@ -96,10 +102,9 @@ is the number to read. Use `npx promptfoo@latest view` for the side-by-side.
   assert:
     - type: skill-used
       value: 'vgv-ai-flutter-plugin:bloc'
+      weight: 3
     - type: regex
       value: 'sealed class LoginEvent'
-    - type: not-regex
-      value: 'package:mockito'
     - type: javascript
       value: file://assertions/dart-parses.js
     - type: llm-rubric
@@ -108,280 +113,233 @@ is the number to read. Use `npx promptfoo@latest view` for the side-by-side.
         verb, for example LoginSubmitted.
 ```
 
-`defaultTest.threshold` in the config is `0.8`, so each case passes when its
-assertions average that or better. The threshold is per-case, so a weak case cannot
-hide behind strong siblings.
+### Threshold and routing weight
 
-**Routing carries `weight: 3`.** Every `skill-used` and `not-skill-used` assertion is
-weighted so a routing miss cannot clear the threshold on its own. Unweighted it could: a
-six-assertion case whose only failure was `skill-used` averaged `0.83` and reported
-green, which is how a measured bloc routing failure went unnoticed for a whole run.
+`defaultTest.threshold` is `0.8`, so a case passes when its assertions average that or
+better. The threshold is per-case, so a weak case cannot hide behind strong siblings.
 
-Writing `n` for a case's non-routing assertions, which range from 1 to 8 across this
-suite, a routing miss scores `n / (n + 3)`, at most `0.727`. Three is the smallest
-weight that holds for every case size: a routing miss clears `0.8` whenever the weight
-is below `n / 4`, so `1` and `2` both leave the largest cases masked.
+**Every `skill-used` and `not-skill-used` assertion carries `weight: 3`**, so a routing
+miss cannot clear the threshold on its own. Unweighted it could: a six-assertion case
+whose only failure was `skill-used` averaged `0.83` and reported green, which is how a
+measured bloc routing failure went unnoticed for a whole run.
 
-**Weight 3 has a cost, and it is not symmetric.** On the five cases with 7 or more
-content assertions, two content failures now score `0.818` or `0.900` and pass, where
-unweighted they scored `0.75` to `0.778` and failed. Routing got stricter and the
-content bar on the largest cases got looser. Raising the weight makes that worse rather
-than better, because routing then dominates the average and each content assertion
-carries less. It is a property of averaging, not of the number. If a large case needs
-its two-miss strictness back, that is a per-case fix.
+Writing `n` for a case's non-routing assertions, which range from 1 to 8 here, a routing
+miss scores `n / (n + 3)`, at most `0.727`. Three is the smallest weight that holds for
+every case size, because a routing miss clears `0.8` whenever the weight is below
+`n / 4`. The cost is asymmetric and worth knowing: on the five cases with 7 or more
+content assertions, two content failures now score `0.818` to `0.900` and pass, where
+unweighted they failed. Raising the weight makes that worse rather than better, since
+routing then dominates the average. Restoring two-miss strictness on a large case is a
+per-case fix. The one-soft-miss tolerance holds for `n >= 2`. The two `n = 1` cases fail
+on a single content miss, as they did unweighted.
 
-The one-soft-miss tolerance holds for `n >= 2`. The two `n = 1` cases fail on their
-single content miss, as they did unweighted.
-
-Keep the weight on routing assertions in new cases. Nothing enforces it automatically.
+Nothing enforces the weight on new cases automatically.
 
 ### Assertions
 
-| `type` | Measures | Notes |
-| ------ | -------- | ----- |
-| `skill-used` / `not-skill-used` | process | Reads `metadata.skillCalls`, which promptfoo derives from `Skill` tool calls. Errored skill attempts do not satisfy it. Always `weight: 3` — see the threshold note above |
-| `regex` / `not-regex` | style | Any assertion negates with a `not-` prefix |
-| `contains` / `icontains` / `not-icontains` | outcome | Case-insensitive variants for one-word answers |
-| `llm-rubric` | style | Model-graded against a criterion |
-| `javascript` | outcome, process | `file://assertions/*.js` — promptfoo resolves `file://` against the config file's directory, even from a test file — or inline reading `context.providerResponse.metadata` |
+| `type`                                     | Measures         | Notes                                                                                                                                               |
+| ------------------------------------------ | ---------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `skill-used` / `not-skill-used`            | process          | Reads `metadata.skillCalls`, derived from `Skill` tool calls. Errored skill attempts do not satisfy it. Always `weight: 3`                          |
+| `regex` / `not-regex`                      | style            | Any assertion negates with a `not-` prefix                                                                                                          |
+| `contains` / `icontains` / `not-icontains` | outcome          | Case-insensitive variants for one-word answers                                                                                                      |
+| `llm-rubric`                               | style            | Model-graded against a criterion                                                                                                                    |
+| `javascript`                               | outcome, process | `file://assertions/*.js`, resolved against the config file's directory even from a test file, or inline reading `context.providerResponse.metadata` |
 
-One custom assertion lives in `evals/assertions/`:
-
-- **`dart-parses.js`** — every fenced ```` ```dart ```` block parses. Runs
-  `dart format --output=none`, which parses without resolving, because snippets
-  reference classes absent from the fixture and semantic analysis would fail every
-  case. A block is tried three ways before it counts as a failure: as-is, wrapped in a
-  function body for a statement like `ArticleRoute(id).go(context);`, and wrapped as an
-  expression for a widget tree pasted with no trailing semicolon. The third shape was
-  added after a measured run failed three cases whose Dart was fine — a bare
-  `AppButton(label: 'Save')` is neither a compilation unit nor a statement. Verified
-  that it still rejects unbalanced parens, stray keywords and truncated classes.
+`evals/assertions/dart-parses.js` checks that every fenced ```` ```dart ```` block
+parses. It runs `dart format --output=none`, which parses without resolving, because
+snippets reference classes absent from the fixture and semantic analysis would fail
+every case. Each block is tried three ways before counting as a failure: as-is, wrapped
+in a function body for a bare statement, and wrapped as an expression for a widget tree
+pasted with no trailing semicolon. The third shape was added after a run failed three
+cases whose Dart was fine. It still rejects unbalanced parens, stray keywords and
+truncated classes.
 
 **Rubrics are graded blind.** The judge sees the response text and the criterion, never
-the prompt. So a criterion like "the response fixes the loop bound" is unanswerable, and
-it fails at random: both columns once returned byte-identical correct output for
-`layered-architecture-stays-out-of-single-file-work` and the judge scored one 1.00 and
-the other 0.30. Grade task success with a `regex` and keep the rubric to properties
-visible in the text alone.
-
-### Isolation is held by the config alone
-
-`skills` is a context filter, not a sandbox. Skill files stay on disk and readable
-through Read, Glob and Grep, and `working_dir` points inside this checkout. A run that
-never invoked a skill yet opened `SKILL.md` had the answers, so its score measures
-nothing. That is not hypothetical: the sealed baseline read `skills/bloc/SKILL.md` off
-disk on a stock run and then passed the rubric it should have failed.
-
-Nothing detects that automatically. The three keys in the table above are the only
-thing holding isolation, and it has broken twice here by one of them being loosened. So
-treat any change to `tools`, `working_dir`, `setting_sources` or `plugins` as
-invalidating every number measured before it, and re-baseline rather than comparing
-across the change.
-
-The symptom to watch for is the sealed column climbing toward the plugin column. That
-reads like the model improving and is almost always contamination.
-
-### Skill routing is tested, not assumed
-
-Prompts name no skill. With `skills: all` the model routes on its own, and
-`skill-used` makes a routing failure visible as its own failed assertion instead of as
-unexplained content failures downstream. Negative controls invert it: every skill has
-one case asserting `not-skill-used`, so a skill firing where it should not is caught
-rather than inferred from the prose.
-
-The slash-command path cannot be measured this way: invoking a skill as `/<name>`
-expands its content into the prompt with no `Skill` tool call, so routing is only
-observable when the model chooses the skill itself.
+the prompt. A criterion like "the response fixes the loop bound" is therefore
+unanswerable and fails at random: both columns once returned byte-identical correct
+output and the judge scored one `1.00` and the other `0.30`. Grade task success with a
+`regex` and keep rubrics to properties visible in the text alone.
 
 ### The fixture must stay neutral
 
-Both providers use `working_dir: ./fixture`, a bare Flutter app skeleton. An entirely
-empty directory is its own confound — with no project in sight the model asks for the
-code instead of writing it, and graders fail for reasons unrelated to the skill.
+Both columns use `working_dir: ./fixture`, a bare Flutter app skeleton. An entirely
+empty directory is its own confound, because with no project in sight the model asks for
+the code instead of writing it and graders fail for unrelated reasons.
 
-An earlier version of that pubspec listed `bloc`, `flutter_bloc`, `equatable`,
-`mocktail` and `very_good_analysis`. The sealed column read the dependency list and
-inferred the conventions the skills exist to supply, collapsing bloc's measured lift
-from +10 points to +1. If anything in the fixture hints at what a skill teaches, it is
-handing the baseline the answers. Keep it to what a new Flutter app ships with.
+An earlier version of that pubspec listed `bloc`, `flutter_bloc`, `equatable`, `mocktail`
+and `very_good_analysis`. The sealed column read the dependency list, inferred the
+conventions the skills exist to supply, and collapsed bloc's measured lift from +10
+points to +1. If anything in the fixture hints at what a skill teaches, it is handing the
+baseline the answers. Keep it to what a new Flutter app ships with.
 
-Prompts must be self-contained for the same reason: the fixture has no source in
-`lib/`, so a prompt about "my AuthService" earns a careful refusal. Paste the class
-into the prompt rather than adding source to the fixture.
+Prompts must be self-contained for the same reason. The fixture has no source in `lib/`,
+so a prompt about "my AuthService" earns a careful refusal. Paste the class into the
+prompt, and name pasted text as authoritative when the prompt describes state that is not
+on disk, or a run will go looking for it and answer about the empty fixture instead.
 
-### Running the suite
+### Routing is tested, not assumed
+
+Prompts name no skill. With `skills: all` the model routes on its own, and `skill-used`
+makes a routing failure legible as its own failed assertion instead of as unexplained
+content failures downstream. Every skill also has one negative control asserting
+`not-skill-used`, so a skill firing where it should not is caught rather than inferred.
+
+The slash-command path cannot be measured this way. Invoking a skill as `/<name>` expands
+its content into the prompt with no `Skill` tool call, so routing is only observable when
+the model chooses the skill itself.
+
+### Checklist
+
+1. **Write the prompt as a user would send it**, with real phrasing and real ambiguity.
+2. **Make it self-contained.** Paste in any class it refers to.
+3. **Add `skill-used` at `weight: 3`.** The one exception is a prompt demanding a single
+   token, which does not justify a Skill round-trip and would measure the harness. Three
+   cases omit it and each says so in a comment. If you omit it, leave the comment.
+4. **Grade mechanically where you can**, a required import or a forbidden package, and
+   with `llm-rubric` where the property is structural.
+5. **Only ask for what the prompt supplied.** A rubric wanting per-failure detail from a
+   prompt that gave none can never pass, and a rubric wanting prose will always fail a
+   prompt ending "Output Dart code only".
+6. **Include the cases where the skill must say no.** Ask for the anti-pattern outright
+   and grade that the response declines and offers the alternative. A skill earns its
+   keep on its prohibitions.
+7. **Keep the negative control's rubric to the absence of the skill's vocabulary**, and
+   grade the task itself with a `regex`. A negative control whose rubric also asks "did
+   it do the task" hits the blind-judge trap above.
+8. **Write criteria a stranger could apply** from the response text alone, naming what
+   satisfies them and what does not.
+9. **Check it beats the baseline.** An assertion that passes in the sealed column too is
+   measuring Claude, not your skill. One case was dropped for scoring `1.00` in both.
+
+---
+
+## Running the suite
 
 ```bash
 P="npx promptfoo@latest"
-$P eval -c evals/promptfooconfig.yaml                          # all 100, both columns
-$P eval -c evals/promptfooconfig.yaml --filter-pattern bloc    # one skill
-$P eval -c evals/promptfooconfig.yaml --repeat 2 --no-cache    # is a red case real?
-$P eval -c evals/promptfooconfig.yaml --retry-errors           # re-run 529s only
-$P view                                                        # the side-by-side
+$P eval -c evals/promptfooconfig.yaml                            # all 100, both columns
+$P eval -c evals/promptfooconfig.yaml --filter-pattern bloc      # one skill
+$P eval -c evals/promptfooconfig.yaml --filter-providers with-skill
+$P eval -c evals/promptfooconfig.yaml --repeat 3 --no-cache      # is a red case real?
+$P eval -c evals/promptfooconfig.yaml --retry-errors             # re-run 529s only
+$P view                                                          # the side-by-side
 ```
 
 **Read the per-column split, not promptfoo's total.** The sealed column is meant to fail,
-so roughly a third of the 200 results failing is the healthy shape, not a regression. Write
-the run to the gitignored `evals/.runs/`, then split it:
+so roughly a third of the 200 results failing is the healthy shape. Write the run to the
+gitignored `evals/.runs/`, then split it:
 
 ```bash
 $P eval -c evals/promptfooconfig.yaml --no-table -o evals/.runs/latest.json
 node -e 'const r=require("./evals/.runs/latest.json"),c={};for(const x of r.results.results){const l=x.provider.label;c[l]??={n:0,pass:0};c[l].n++;c[l].pass+=x.success?1:0}console.table(c)'
 ```
 
-Measured baseline. Full run, `--no-cache`, 200 results, 24 minutes. Negative controls
-excluded because a sealed model passes `not-skill-used` for free:
+`node evals/ci-summary.js evals/.runs/latest.json` renders the same run as the per-skill
+table CI posts. It buckets errored results separately, so a skill whose cases errored
+reads as thin coverage rather than as failures.
 
-| Skill | `with-skill` | `sealed` | Lift |
-| ----- | ------------ | -------- | ---- |
-| create-project | 6/6 | 0/6 | 100 pt |
-| green-gate | 6/6 | 0/6 | 100 pt |
-| ui-package | 6/6 | 0/6 | 100 pt |
-| static-security | 6/6 | 0/6 | 100 pt |
-| layered-architecture | 6/6 | 0/6 | 100 pt |
-| navigation | 6/6 | 0/6 | 100 pt |
-| internationalization | 5/5 | 0/5 | 100 pt |
-| testing | 5/5 | 0/5 | 100 pt |
-| accessibility | 6/6 | 1/6 | 83 pt |
-| animations | 5/6 | 0/6 | 83 pt |
-| dart-flutter-sdk-upgrade | 5/6 | 0/6 | 83 pt |
-| very-good-analysis-upgrade | 5/6 | 0/6 | 83 pt |
-| material-theming | 4/5 | 0/5 | 80 pt |
-| bloc | 4/5 | 1/5 | 60 pt |
-| license-compliance | 4/5 | 1/5 | 60 pt |
-| **total** | **79/85** | **3/85** | **89 pt** |
+**One run is not a measurement.** These are non-deterministic and they are not a merge
+gate. Treat a single red case as a prompt to look, never as proof of a regression:
 
-The sealed column made zero tool calls, so isolation held. Six skills were fixed on the
-strength of this suite's findings, which is what moved the total from 57/85; the two with
-no case changes at all, `static-security` and `material-theming`, went 4/6 → 6/6 and
-2/5 → 4/5, so their gains isolate skill work from case work.
+- `--no-cache` is required for fresh generations, since promptfoo caches by default.
+- `--repeat 3` before editing anything. Unedited cases have been measured moving between
+  runs, one across the pass/fail line, and cases drifting between 2/3 and 3/3 are this
+  suite's noise floor. Two skills were nearly "fixed" off single red reps that a repeat
+  run showed were noise.
+- A `529 Overloaded` scores 0 with no failing assertion, indistinguishable from a content
+  failure unless you check `res.error`. One full run hit 14 of them, and a long local run
+  hit 19 clustered in its final 12% as the session throttled. Follow up with
+  `--retry-errors` before believing a failure count.
+- Variance in the plugin column is mostly routing rather than content.
 
-The plugin column is not reliably perfect, and the variance is routing rather than content.
-A red case there is worth a `--repeat 3` before it is worth an edit: `bloc` dropped 5/5 →
-4/5 on an unedited case that returned no test code at all, and an unedited `material-theming`
-case moved 0.27 on its own. If the sealed column climbs toward the other one, isolation has
-broken rather than the model having improved — that has already happened twice here.
+Budget roughly $0.10 to $0.20 and 10 to 30 seconds per case per provider, so a full
+two-column run of 100 cases lands near $20 to $40 of equivalent usage and well over half
+an hour. A 300-case `--repeat 3` run took 4h32m locally. Use `--filter-pattern` while
+iterating. A full run is a release-time check, not an edit-loop one.
 
-Two things about the numbers. promptfoo caches by default, so `--no-cache` is needed
-for fresh generations, and `--repeat N` shows the noise floor. And a `529 Overloaded`
-scores 0 with no failing assertion, which is indistinguishable from a content failure
-unless you check `res.error` — one full run hit 14 of them, so always follow up with
-`--retry-errors` before believing a failure count.
+---
 
-Expect roughly $0.10–0.20 and 10–30 seconds per case per provider, so a full run of 100
-cases across both columns lands around $20–40 of equivalent usage and well over half an
-hour. Use `--filter-pattern <skill>` while iterating; a full run is a release-time check,
-not an edit-loop one.
+## Running in CI
 
-These are not a merge gate. They are non-deterministic and a single rubric verdict can
-move a case, so treat one red case as a prompt to look rather than proof of a
-regression. `--repeat 2` is the cheapest way to tell a real failure from noise.
+`.github/workflows/evals.yaml` runs these **after a merge to `main`**, never on a pull
+request. Three choices keep the bill down, and each costs something:
 
-### Running in CI
+| Choice                   | Saves                                                    | Costs                                                            |
+| ------------------------ | -------------------------------------------------------- | ---------------------------------------------------------------- |
+| Post-merge, not per-PR   | A PR is pushed to many times, `main` is merged into once | A regression is reported after it lands                          |
+| Only the changed skills  | One skill is 6 or 7 cases out of 100                     | A change affecting routing globally can be missed                |
+| `with-skill` column only | Half of every run                                        | No ablation, so it cannot tell you a case stopped discriminating |
 
-`.github/workflows/evals.yaml` runs them **after a merge to `main`**, never on a pull
-request. Three choices keep the bill down, and each one costs something:
+Dropping the sealed column is the safe half of that. The baseline exists to prove a case
+*discriminates*, which you answer once when writing the case. Regression detection does
+not need it. Re-check it deliberately with the `include_baseline` input.
 
-| Choice | Saves | Costs |
-| ------ | ----- | ----- |
-| Post-merge, not per-PR | A PR is pushed to many times; `main` is merged into once | A regression is reported after it lands |
-| Only the changed skills | One skill is 6–7 cases out of 100 | A change that affects routing globally can be missed |
-| `with-skill` column only | Half of every run | No ablation, so it cannot tell you a case has stopped discriminating |
-
-Dropping the sealed column is the safe half of that. The baseline exists to prove a *case
-discriminates*, which you answer once when writing the case. Regression detection does not
-need it. Re-check it deliberately with the `include_baseline` input, not on every run.
+A change to `promptfooconfig.yaml`, `assertions/` or `fixture/` widens the scope to all
+15 skills, since any of them can affect every case.
 
 Cost is bounded rather than estimated. `max_budget_usd` is enforced per case, so the
-ceiling is `cases × columns × max_budget_usd`: about **$3.50** for a one-skill merge at the
-current `0.5`, and **$100** for a full two-column run. Typical spend is far below the
-ceiling — a full run measured 274k tokens — but the ceiling is the number to put in a
-budget alarm, and a case that hits it errors rather than overspending.
+ceiling is `cases × columns × max_budget_usd`: about **$3.50** for a one-skill merge at
+the current `0.5`, and **$100** for a full two-column run. Typical spend is far below
+that, but the ceiling is the number for a budget alarm, and a case that hits it errors
+rather than overspending.
 
-Two things about the CI path that the local path does not have:
+Two differences from the local path:
 
-- **It needs `ANTHROPIC_API_KEY`.** Locally both providers set `apiKeyRequired: false` and
-  authenticate through the Claude Code session; CI has no session. The workflow runs a
-  one-case smoke test first so an auth problem fails in seconds instead of after a full
-  matrix.
-- **It is `continue-on-error`.** Deliberate. Two unedited cases have been measured moving
-  between runs, one across the pass/fail line, so a red result is a signal to look rather
-  than a verdict. Confirm locally with `--repeat 3`.
+- **It needs `ANTHROPIC_API_KEY`.** Locally both providers set `apiKeyRequired: false`
+  and use the Claude Code session, while CI has none. The workflow runs a one-case smoke
+  test first so an auth problem fails in seconds rather than after a full matrix.
+- **It is `continue-on-error`**, deliberately, for the variance reasons above. Confirm
+  anything red locally with `--repeat 3`.
 
-For a full run before a release, use the manual trigger with `scope: all-skills`.
+The job has a one-hour ceiling. 100 cases in one column fits. A `--repeat 3` dispatch
+does not, and will be cancelled without writing an artifact. Shard by skill across
+parallel jobs if that mode is wanted. For a full run before a release, use the manual
+trigger with `scope: all-skills`.
 
-### What these evals do not cover
+---
 
-| Not covered | Why |
-| ----------- | --- |
-| **Judge calibration** | 164 assertions are `llm-rubric` with no human-labelled gold set and no measured agreement. Strong judges reach roughly 80% agreement with humans, and raw agreement can read 90% while a judge does nothing meaningful. Until someone hand-labels a sample, rubric verdicts are unverified — and `llm-rubric` does not calibrate itself |
-| **Tool execution** | No MCP servers are configured, so the six skills whose real job is calling tools or mutating files — `create-project`, `green-gate`, `license-compliance`, `ui-package`, `dart-flutter-sdk-upgrade`, `very-good-analysis-upgrade` — are graded only on the decisions they narrate. Their numbers are weaker evidence than the other nine skills' by construction |
-| **Whether the code compiles** | `dart_parses` proves syntax only. Snippets reference classes absent from the fixture |
-| **Judge independence** | Generator and rubric grader are the same model family and may share blind spots |
-| **Repeat measurement** | All 100 cases have been run once with `--no-cache`. A single run is not a noise floor: two unedited cases moved on their own between runs, one of them across the pass/fail line. Nothing here has been run with `--repeat` at the suite level |
-| **Stable routing** | Whether a skill activates is itself nondeterministic. `testing-declines-mockito` routed 3 of 3 on one pass and failed to route on the next, taking every downstream assertion with it. This is why `skill-used` is its own assertion rather than inferred from content |
-| **Prose in a `SKILL.md`** | Deliberate. An earlier version asserted about a hundred `contains` patterns against skill bodies, so a copy-edit failed the gate while teaching exactly the same thing |
-| **The skills' own surfaces** | Nothing verifies that a name in `allowed-tools` still exists, that a markdown link to a reference file resolves, or that `name` agrees with the directory. See below |
+## What these evals do not cover
 
-Nothing checks the surfaces either. `claude plugin validate .` in CI does not cover
-them — it was measured passing with a bogus tool name, a broken reference link, and a
-`name`/folder mismatch all in place at once. So three frontmatter invariants are held
-by convention alone:
+| Not covered                   | Why                                                                                                                                                                                                                                                                                        |
+| ----------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **Judge calibration**         | Most assertions are `llm-rubric` with no human-labelled gold set and no measured agreement. Strong judges reach roughly 80% agreement with humans, and raw agreement can read 90% while a judge does nothing meaningful. Rubric verdicts are unverified until someone hand-labels a sample |
+| **Tool execution**            | No MCP servers are configured, so the six skills whose real job is calling tools or mutating files, `create-project`, `green-gate`, `license-compliance`, `ui-package`, `dart-flutter-sdk-upgrade` and `very-good-analysis-upgrade`, are graded only on the decisions they narrate         |
+| **Whether the code compiles** | `dart-parses` proves syntax only. Snippets reference classes absent from the fixture                                                                                                                                                                                                       |
+| **Judge independence**        | Generator and rubric grader are the same model family and may share blind spots                                                                                                                                                                                                            |
+| **Stable routing**            | Whether a skill activates is itself nondeterministic. One case routed 3 of 3 on one pass and failed to route on the next, taking every downstream assertion with it. This is why `skill-used` is its own assertion                                                                         |
+| **Prose in a `SKILL.md`**     | Deliberate. An earlier version asserted about a hundred `contains` patterns against skill bodies, so a copy-edit failed the gate while teaching the same thing                                                                                                                             |
+| **The skills' own surfaces**  | Nothing verifies that a name in `allowed-tools` still exists, that a markdown link to a reference resolves, or that `name` agrees with the directory. See below                                                                                                                            |
 
-- `create-project` must not declare `Bash` — scaffolding goes through the Very Good
-  CLI MCP server, and `block-cli-workarounds.sh` blocks the Bash path
-- `green-gate` must declare `Bash` — the coverage gate parses `coverage/lcov.info`, and
-  no MCP tool reads it. Bash is reserved for that; every gate itself runs through a tool
-- `.mcp.json` must keep `--enable dart_format` — the Dart MCP server's `cli` feature
-  category is off by default, so dropping the flag leaves `green-gate`'s format gate
-  naming a tool the client never sees
-- the `flutter-reviewer` agent must declare no `Edit`, `Write` or `NotebookEdit` —
-  `tools` cannot scope Bash by command, so a read-only agent has to omit write tools
-  entirely
+`claude plugin validate .` does not cover the surfaces either. It was measured passing
+with a bogus tool name, a broken reference link, and a `name`/folder mismatch all in
+place at once. Four invariants are held by convention alone:
 
-The failure mode to watch for is a Claude Code or MCP release renaming a tool. A skill still
-naming the old one breaks silently. Cases catch this only where the skill's output changes as
-a result, so the six narration-graded skills are the weak spot: they describe the tool they
-would call, and a case asserting that description keeps passing after the tool ceases to
-exist. `green-gate` shipped exactly that bug: it named `mcp__dart__dart_format` while
-`.mcp.json` started the server without `--enable dart_format`, so the gate called a tool the
-client was never offered. Note the shape of it — the tool existed the whole time, in a feature
-category the server disables by default. A name can be correct and still unreachable, so
-checking the tool exists somewhere is not the same as checking this config exposes it.
+- `create-project` must not declare `Bash`, because scaffolding goes through the Very
+  Good CLI MCP server and `block-cli-workarounds.sh` blocks the Bash path
+- `green-gate` must declare `Bash`, because the coverage gate parses
+  `coverage/lcov.info` and no MCP tool reads it
+- `.mcp.json` must keep `--enable dart_format`, because the Dart MCP server's `cli`
+  feature category is off by default
+- the `flutter-reviewer` agent must declare no `Edit`, `Write` or `NotebookEdit`, because
+  `tools` cannot scope Bash by command
 
-### Adding a case
-
-1. **Write the prompt as a user would send it.** Real phrasing, real ambiguity.
-2. **Make it self-contained.** Paste in any class the prompt refers to.
-3. **Add `skill-used`** so a routing failure is legible on its own. The one exception
-   is a prompt demanding a single token ("Answer with only the template name"), which
-   does not justify a Skill round-trip and measures the harness instead — three cases
-   omit it for that reason and each says so in a comment. If you omit it, leave the
-   comment.
-4. **Grade mechanically where you can** — a required import, a `sealed class`, a
-   forbidden package — and with `llm-rubric` where the property is structural.
-5. **Include the cases where the skill must say no.** Ask for the anti-pattern
-   outright and grade that the response declines and offers the alternative. A skill
-   earns its keep on its prohibitions.
-6. **Keep one negative control per skill**, asserting `not-skill-used`. Grade only the
-   *absence* of the skill's vocabulary in the rubric, and the task itself with a
-   `regex`. A negative control whose rubric also asks "did it do the task" is the
-   blind-judge trap above.
-7. **Write rubric criteria a stranger could apply**, using only the response text.
-   Name what satisfies it and what does not.
-8. **Check it beats the baseline.** If the assertion passes in the sealed column too,
-   it is measuring Claude, not your skill. Strengthen it or drop it. One case was
-   dropped for exactly this after scoring 1.00 in both columns.
-9. **Do not ask for what the prompt forbade.** A rubric wanting prose about
-   `build_runner` will always fail a prompt ending "Output Dart code only".
+The failure mode to watch for is a Claude Code or MCP release renaming a tool. A skill
+still naming the old one breaks silently, and the six narration-graded skills are the
+weak spot: they describe the tool they would call, so a case asserting that description
+keeps passing after the tool ceases to exist. `green-gate` shipped exactly that bug,
+naming `mcp__dart__dart_format` while `.mcp.json` started the server without
+`--enable dart_format`. Note the shape of it. The tool existed the whole time, in a
+feature category the server disables by default, so checking that a tool exists
+somewhere is not the same as checking that this config exposes it.
 
 ---
 
 ## When to update what
 
-| You changed | Do this |
-| ----------- | ------- |
-| Added a skill | Add `evals/tests/<skill>.yaml` and register it under `tests:` |
-| What a skill teaches | Run its cases and update any that asserted the old behavior |
-| A skill's reference layout | Update every markdown link to the moved file by hand |
-| A skill's `allowed-tools` | Confirm by hand that every name still exists |
+| You changed                | Do this                                                       |
+| -------------------------- | ------------------------------------------------------------- |
+| Added a skill              | Add `evals/tests/<skill>.yaml` and register it under `tests:` |
+| What a skill teaches       | Run its cases and update any that asserted the old behavior   |
+| A skill's reference layout | Update every markdown link to the moved file by hand          |
+| A skill's `allowed-tools`  | Confirm by hand that every name still exists                  |
+| `promptfooconfig.yaml`     | Re-baseline. Earlier numbers are not comparable across it     |

--- a/evals/README.md
+++ b/evals/README.md
@@ -113,13 +113,27 @@ assertions average that or better. The threshold is per-case, so a weak case can
 hide behind strong siblings.
 
 **Routing carries `weight: 3`.** Every `skill-used` and `not-skill-used` assertion is
-weighted so a routing miss cannot clear the threshold on its own. Unweighted it could:
-a six-assertion case whose only failure was `skill-used` averaged `0.83` and reported
-green, which is how a measured bloc routing failure went unnoticed for a whole run. At
-weight 3 a routing miss with every content assertion passing scores `n / (n + 3)` — at
-most `0.75` for the case sizes here — while a single content miss with routing intact
-still clears, so the deliberate one-soft-miss tolerance survives. Keep the weight on
-routing assertions in new cases; nothing enforces it automatically.
+weighted so a routing miss cannot clear the threshold on its own. Unweighted it could: a
+six-assertion case whose only failure was `skill-used` averaged `0.83` and reported
+green, which is how a measured bloc routing failure went unnoticed for a whole run.
+
+Writing `n` for a case's non-routing assertions, which range from 1 to 8 across this
+suite, a routing miss scores `n / (n + 3)`, at most `0.727`. Three is the smallest
+weight that holds for every case size: a routing miss clears `0.8` whenever the weight
+is below `n / 4`, so `1` and `2` both leave the largest cases masked.
+
+**Weight 3 has a cost, and it is not symmetric.** On the five cases with 7 or more
+content assertions, two content failures now score `0.818` or `0.900` and pass, where
+unweighted they scored `0.75` to `0.778` and failed. Routing got stricter and the
+content bar on the largest cases got looser. Raising the weight makes that worse rather
+than better, because routing then dominates the average and each content assertion
+carries less. It is a property of averaging, not of the number. If a large case needs
+its two-miss strictness back, that is a per-case fix.
+
+The one-soft-miss tolerance holds for `n >= 2`. The two `n = 1` cases fail on their
+single content miss, as they did unweighted.
+
+Keep the weight on routing assertions in new cases. Nothing enforces it automatically.
 
 ### Assertions
 

--- a/evals/promptfooconfig.yaml
+++ b/evals/promptfooconfig.yaml
@@ -100,7 +100,10 @@ defaultTest:
   # per-case, so a weak case cannot hide behind strong siblings. Routing assertions
   # carry `weight: 3` in the case files so a `skill-used` miss always lands below this
   # line — unweighted, a six-assertion case failing only on routing averaged 0.83 and
-  # reported green. See the threshold note in README.md.
+  # reported green. 3 is the smallest weight that holds for every case size here, and
+  # it buys that strictness by letting two content misses pass on the five cases with
+  # 7+ content assertions. Read the threshold note in README.md before changing either
+  # number; raising the weight loosens content further rather than tightening it.
   threshold: 0.8
   # Do not add a harness self-check as an assertion here. Isolation is a *validity*
   # question, not a graded one, and an assertion that returns true on every clean run

--- a/evals/promptfooconfig.yaml
+++ b/evals/promptfooconfig.yaml
@@ -97,7 +97,10 @@ defaultTest:
         strict_mcp_config: true
         max_turns: 2
   # A case passes when its assertions average this or better. The threshold is
-  # per-case, so a weak case cannot hide behind strong siblings.
+  # per-case, so a weak case cannot hide behind strong siblings. Routing assertions
+  # carry `weight: 3` in the case files so a `skill-used` miss always lands below this
+  # line — unweighted, a six-assertion case failing only on routing averaged 0.83 and
+  # reported green. See the threshold note in README.md.
   threshold: 0.8
   # Do not add a harness self-check as an assertion here. Isolation is a *validity*
   # question, not a graded one, and an assertion that returns true on every clean run

--- a/evals/tests/accessibility.yaml
+++ b/evals/tests/accessibility.yaml
@@ -91,6 +91,7 @@
     # routing
     - type: skill-used
       value: 'vgv-ai-flutter-plugin:accessibility'
+      weight: 3
     # mechanical
     - type: regex
       value: 'AA \+ selected AAA'
@@ -163,6 +164,7 @@
     # routing
     - type: skill-used
       value: 'vgv-ai-flutter-plugin:accessibility'
+      weight: 3
     # mechanical
     - type: regex
       value: '2\.5\.8'
@@ -207,6 +209,7 @@
     # routing
     - type: skill-used
       value: 'vgv-ai-flutter-plugin:accessibility'
+      weight: 3
     # mechanical
     # The documented replacement list from the Gesture Detector core standard.
     - type: regex
@@ -269,6 +272,7 @@
     # routing
     - type: skill-used
       value: 'vgv-ai-flutter-plugin:accessibility'
+      weight: 3
     # mechanical
     # With the paren, so the fix has to arrive as code. The sealed column named
     # MergeSemantics in prose, as a possible cause rather than the fix.
@@ -336,6 +340,7 @@
     # routing
     - type: skill-used
       value: 'vgv-ai-flutter-plugin:accessibility'
+      weight: 3
     # mechanical
     - type: regex
       value: 'liveRegion'
@@ -395,6 +400,7 @@
     # routing
     - type: skill-used
       value: 'vgv-ai-flutter-plugin:accessibility'
+      weight: 3
     # mechanical
     - type: regex
       value: 'IconButton'
@@ -440,6 +446,7 @@
     # routing
     - type: not-skill-used
       value: 'vgv-ai-flutter-plugin:accessibility'
+      weight: 3
     # mechanical
     - type: not-regex
       value: 'Semantics|semanticLabel|WCAG|disableAnimations|excludeFromSemantics'

--- a/evals/tests/animations.yaml
+++ b/evals/tests/animations.yaml
@@ -59,6 +59,7 @@
     # routing
     - type: skill-used
       value: 'vgv-ai-flutter-plugin:animations'
+      weight: 3
     # mechanical
     - type: regex
       value: 'Durations\.'
@@ -99,6 +100,7 @@
     # routing
     - type: skill-used
       value: 'vgv-ai-flutter-plugin:animations'
+      weight: 3
     # mechanical
     # SKILL.md, Anti-Patterns, "Using explicit when implicit suffices": the good
     # form for this exact request is AnimatedOpacity.
@@ -141,6 +143,7 @@
     # routing
     - type: skill-used
       value: 'vgv-ai-flutter-plugin:animations'
+      weight: 3
     # mechanical
     # Performance, Do Not: "Do not create multiple AnimationController instances for
     # animations that share timing — use Interval on a single controller."
@@ -193,6 +196,7 @@
     # routing
     - type: skill-used
       value: 'vgv-ai-flutter-plugin:animations'
+      weight: 3
     # mechanical
     - type: regex
       value: 'CustomTransitionPage'
@@ -265,6 +269,7 @@
     # routing
     - type: skill-used
       value: 'vgv-ai-flutter-plugin:animations'
+      weight: 3
     # mechanical
     - type: regex
       value: 'Durations\.'
@@ -305,6 +310,7 @@
     # routing
     - type: skill-used
       value: 'vgv-ai-flutter-plugin:animations'
+      weight: 3
     # mechanical
     # Core Standards: "durations, curves, and offsets go in named constants or a
     # centralized AppMotion class, not inline."
@@ -339,6 +345,7 @@
     # routing
     - type: not-skill-used
       value: 'vgv-ai-flutter-plugin:animations'
+      weight: 3
     # mechanical
     - type: not-regex
       value: 'AnimationController|AnimatedBuilder|TweenAnimationBuilder|CustomTransitionPage'

--- a/evals/tests/bloc.yaml
+++ b/evals/tests/bloc.yaml
@@ -63,6 +63,7 @@
     # routing
     - type: skill-used
       value: 'vgv-ai-flutter-plugin:bloc'
+      weight: 3
     # mechanical
     - type: regex
       value: 'sealed class LoginEvent'
@@ -115,6 +116,7 @@
     # routing
     - type: skill-used
       value: 'vgv-ai-flutter-plugin:bloc'
+      weight: 3
     # mechanical
     - type: regex
       value: 'blocTest'
@@ -150,6 +152,7 @@
     # routing
     - type: skill-used
       value: 'vgv-ai-flutter-plugin:bloc'
+      weight: 3
     # mechanical
     - type: regex
       value: 'BlocProvider'
@@ -185,6 +188,7 @@
     # routing
     - type: skill-used
       value: 'vgv-ai-flutter-plugin:bloc'
+      weight: 3
     # judged
     - type: llm-rubric
       value: >-
@@ -224,6 +228,7 @@
     # routing
     - type: skill-used
       value: 'vgv-ai-flutter-plugin:bloc'
+      weight: 3
     # mechanical
     - type: regex
       value: 'extends Bloc<'
@@ -253,6 +258,7 @@
     # routing
     - type: not-skill-used
       value: 'vgv-ai-flutter-plugin:bloc'
+      weight: 3
     # mechanical
     - type: not-regex
       value: 'BlocProvider|BlocBuilder|extends Bloc<|extends Cubit<'

--- a/evals/tests/create-project.yaml
+++ b/evals/tests/create-project.yaml
@@ -84,6 +84,7 @@
     # routing
     - type: skill-used
       value: 'vgv-ai-flutter-plugin:create-project'
+      weight: 3
     # judged
     - type: llm-rubric
       value: >-
@@ -118,6 +119,7 @@
     # routing
     - type: skill-used
       value: 'vgv-ai-flutter-plugin:create-project'
+      weight: 3
     # mechanical
     # Both surface forms count: the MCP tool is `packages_get`, the shell equivalent is
     # `very_good packages get`. An earlier `icontains: packages_get` failed a correct
@@ -160,6 +162,7 @@
     # routing
     - type: skill-used
       value: 'vgv-ai-flutter-plugin:create-project'
+      weight: 3
     # judged
     - type: llm-rubric
       value: >-
@@ -184,6 +187,7 @@
     # routing
     - type: skill-used
       value: 'vgv-ai-flutter-plugin:create-project'
+      weight: 3
     # judged
     - type: llm-rubric
       value: >-
@@ -210,6 +214,7 @@
     # routing
     - type: skill-used
       value: 'vgv-ai-flutter-plugin:create-project'
+      weight: 3
     # judged
     - type: llm-rubric
       value: >-
@@ -245,6 +250,7 @@
     # routing
     - type: not-skill-used
       value: 'vgv-ai-flutter-plugin:create-project'
+      weight: 3
     # mechanical
     - type: not-regex
       value: 'very_good create|dart_package|flutter_app|--org'

--- a/evals/tests/dart-flutter-sdk-upgrade.yaml
+++ b/evals/tests/dart-flutter-sdk-upgrade.yaml
@@ -78,6 +78,7 @@
     # routing
     - type: skill-used
       value: 'vgv-ai-flutter-plugin:dart-flutter-sdk-upgrade'
+      weight: 3
     # mechanical
     # `[^\n^]{0,3}` absorbs the optional quoting, and excluding `^` from the class makes
     # `flutter_version: "^3.41.x"` fail. No mirroring `not-regex` on `3.41.0`: a correct
@@ -135,6 +136,7 @@
     # routing
     - type: skill-used
       value: 'vgv-ai-flutter-plugin:dart-flutter-sdk-upgrade'
+      weight: 3
     # mechanical
     # `^` is excluded from the class rather than bounded by length: with a plain
     # `[^\n]{0,3}` the wrong answer `dart_sdk: "^3.11.0"` matches, since ` "^` is three
@@ -185,6 +187,7 @@
     # routing
     - type: skill-used
       value: 'vgv-ai-flutter-plugin:dart-flutter-sdk-upgrade'
+      weight: 3
     # mechanical
     # The documented source, in either the URL or the named form.
     - type: regex
@@ -240,6 +243,7 @@
     # routing
     - type: skill-used
       value: 'vgv-ai-flutter-plugin:dart-flutter-sdk-upgrade'
+      weight: 3
     # mechanical
     # Proves it still did the in-scope work rather than refusing wholesale. `\b` keeps it
     # off keys that end in `flutter`; the caret is required because pubspec form is never
@@ -290,6 +294,7 @@
     # routing
     - type: skill-used
       value: 'vgv-ai-flutter-plugin:dart-flutter-sdk-upgrade'
+      weight: 3
     # judged
     - type: llm-rubric
       value: >-
@@ -330,6 +335,7 @@
     # routing
     - type: skill-used
       value: 'vgv-ai-flutter-plugin:dart-flutter-sdk-upgrade'
+      weight: 3
     # mechanical
     # The documented scope check. Both halves matter: `git diff` with a name-only listing
     # is what proves the PR touched nothing else.
@@ -384,6 +390,7 @@
     # routing
     - type: not-skill-used
       value: 'vgv-ai-flutter-plugin:dart-flutter-sdk-upgrade'
+      weight: 3
     # mechanical
     - type: not-regex
       value: 'flutter_version|dart_sdk|very_good_workflows|install/archive'

--- a/evals/tests/green-gate.yaml
+++ b/evals/tests/green-gate.yaml
@@ -75,6 +75,7 @@
     # routing
     - type: skill-used
       value: 'vgv-ai-flutter-plugin:green-gate'
+      weight: 3
     # mechanical
     # The analyze gate goes through the Dart MCP server, not `dart analyze` in Bash.
     - type: regex
@@ -133,6 +134,7 @@
     # routing
     - type: skill-used
       value: 'vgv-ai-flutter-plugin:green-gate'
+      weight: 3
     # judged
     - type: llm-rubric
       value: >-
@@ -170,6 +172,7 @@
     # routing
     - type: skill-used
       value: 'vgv-ai-flutter-plugin:green-gate'
+      weight: 3
     # judged
     - type: llm-rubric
       value: >-
@@ -222,6 +225,7 @@
     # routing
     - type: skill-used
       value: 'vgv-ai-flutter-plugin:green-gate'
+      weight: 3
     # mechanical
     # The parameter name is the skill's, not general Dart knowledge.
     - type: regex
@@ -278,6 +282,7 @@
     # routing
     - type: skill-used
       value: 'vgv-ai-flutter-plugin:green-gate'
+      weight: 3
     # mechanical
     # The skill's own term for the comparison that makes "no progress" decidable.
     - type: regex
@@ -325,6 +330,7 @@
     # routing
     - type: skill-used
       value: 'vgv-ai-flutter-plugin:green-gate'
+      weight: 3
     # mechanical
     - type: regex
       value: 'min_coverage'
@@ -366,6 +372,7 @@
     # routing
     - type: not-skill-used
       value: 'vgv-ai-flutter-plugin:green-gate'
+      weight: 3
     # mechanical
     - type: not-regex
       value: 'min_coverage|exclude_coverage|check_ignore|analyze_files|lcov'

--- a/evals/tests/green-gate.yaml
+++ b/evals/tests/green-gate.yaml
@@ -271,13 +271,41 @@
 #                the same reason: naming the gate is nearly free once the skill routes,
 #                the per-failure detail is the discriminator, and an AND rubric hides
 #                which one moved.
+#                This case was the only red one in a 3x run of the whole suite: 1 pass,
+#                2 fails, one of them a routing miss. Both fails traced to the prompt,
+#                not to the skill, and the two prompt changes below fixed it at 3/3 with
+#                SKILL.md untouched. That was verified by ablation — reverting SKILL.md
+#                to its pre-change state and re-running 3x gave the identical 1.00 in
+#                every rep — so resist "fixing" green-gate itself off this case. Two
+#                other cases here moved between 2/3 and 3/3 across runs with no skill
+#                change at all; that band is this file's noise floor, and a single red
+#                rep is not evidence.
+#                Change 1: the round history is named as authoritative, the same harness
+#                insulation cases 2 and 3 of dart-flutter-sdk-upgrade carry. Without it a
+#                run walked the working directory, found the neutral fixture has no Dart
+#                files, and spent the answer on that instead of the escalation question.
+#                Change 2: the four diagnostics are pasted in. Withholding them made the
+#                per-failure rubric unsatisfiable — three repetitions of a response that
+#                escalated correctly, named the gate, and asked for the missing codes
+#                failed it 3/3, because nothing can enumerate detail it was never given.
+#                Softening the rubric to accept a promise was the wrong repair; it would
+#                grade an intention. With the codes present the rubric grades the
+#                behaviour it names. The codes are deliberately unlike any example in
+#                SKILL.md, so a response that pattern-matches an example instead of
+#                reading the prompt shows up as wrong rather than passing.
 - description: green-gate-escalates-when-the-loop-stops-making-progress
   vars:
     prompt: >-
-      You are looping on my package. Round 1 reported 4 analyzer errors. Round 2
-      reported the same 4 errors, same files, same lines. Round 3, identical again. I
-      am going out — you have my permission to keep retrying for as long as it takes,
-      just don't come back to me. What do you do next?
+      You are looping on my package. Round 1 reported 4 analyzer errors:
+      invalid_assignment @ lib/src/session_store.dart:64,
+      argument_type_not_assignable @ lib/src/session_store.dart:71,
+      undefined_getter @ lib/src/sync_worker.dart:19, and
+      must_be_immutable @ lib/src/sync_worker.dart:104. Round 2 reported the same 4,
+      same files, same lines. Round 3, identical again. I am going out — you have my
+      permission to keep retrying for as long as it takes, just don't come back to me.
+      What do you do next? This round history is what you are working from — the
+      package is not in your working directory, so answer from the description rather
+      than looking for it on disk.
   assert:
     # routing
     - type: skill-used

--- a/evals/tests/green-gate.yaml
+++ b/evals/tests/green-gate.yaml
@@ -261,12 +261,14 @@
 #                decision. Split so partial compliance scores partially.
 #                Two demands were then dropped from the split rubrics as unmeasurable
 #                *from this prompt*, not because the skill stops teaching them: the
-#                prompt states only "4 analyzer errors" — no codes, no paths — and
-#                describes no edits, so a response cannot list the actual failures or
-#                name the files it touched. Measured failing against a response that
-#                escalated correctly, named the no-progress trigger, and promised the
-#                diagnostic codes with file:line. SKILL.md "Escalation" still requires
-#                the files-touched list on a real run.
+#                prompt named no diagnostic codes and described no edits, so a response
+#                could not list the actual failures or name the files it touched.
+#                Measured failing against a response that escalated correctly, named the
+#                no-progress trigger, and promised the diagnostic codes with file:line.
+#                Half of that was later reversed: Change 2 below pastes the codes in and
+#                the per-failure rubric is measurable again. The files-touched demand
+#                stays dropped, since the prompt still describes no edits, and SKILL.md
+#                "Escalation" still requires that list on a real run.
 #                Naming the gate and the per-failure detail stay separate rubrics for
 #                the same reason: naming the gate is nearly free once the skill routes,
 #                the per-failure detail is the discriminator, and an AND rubric hides
@@ -300,7 +302,7 @@
       invalid_assignment @ lib/src/session_store.dart:64,
       argument_type_not_assignable @ lib/src/session_store.dart:71,
       undefined_getter @ lib/src/sync_worker.dart:19, and
-      must_be_immutable @ lib/src/sync_worker.dart:104. Round 2 reported the same 4,
+      undefined_method @ lib/src/sync_worker.dart:104. Round 2 reported the same 4,
       same files, same lines. Round 3, identical again. I am going out — you have my
       permission to keep retrying for as long as it takes, just don't come back to me.
       What do you do next? This round history is what you are working from — the

--- a/evals/tests/internationalization.yaml
+++ b/evals/tests/internationalization.yaml
@@ -57,6 +57,7 @@
     # routing
     - type: skill-used
       value: 'vgv-ai-flutter-plugin:internationalization'
+      weight: 3
     # mechanical
     # Each of the next three is a plugin fingerprint, not Flutter common knowledge:
     # Flutter's setup docs use lib/l10n and set neither of the other two keys.
@@ -93,6 +94,7 @@
     # routing
     - type: skill-used
       value: 'vgv-ai-flutter-plugin:internationalization'
+      weight: 3
     # mechanical
     # Matches a real pubspec dependency line, not the package name in prose: a
     # response that declines has to name easy_localization to decline it.
@@ -149,6 +151,7 @@
     # routing
     - type: skill-used
       value: 'vgv-ai-flutter-plugin:internationalization'
+      weight: 3
     # mechanical
     # The Core Standard from both sides. The extension's own body reads
     # `AppLocalizations.of(this)`, so declaring it does not trip the not-regex.
@@ -207,6 +210,7 @@
     # routing
     - type: skill-used
       value: 'vgv-ai-flutter-plugin:internationalization'
+      weight: 3
     # mechanical
     # Core Standard from both sides. The prompt bars repeating the original, so the
     # not-regex cannot fire on an echo of the pasted widget.
@@ -263,6 +267,7 @@
     # routing
     - type: skill-used
       value: 'vgv-ai-flutter-plugin:internationalization'
+      weight: 3
     # mechanical
     # The documented alternative, graded mechanically: the shared widget grows a
     # String field, and the app-level call site supplies it through the extension.
@@ -301,6 +306,7 @@
     # routing
     - type: not-skill-used
       value: 'vgv-ai-flutter-plugin:internationalization'
+      weight: 3
     # mechanical
     - type: not-regex
       value: 'AppLocalizations|context\.l10n|gen-l10n|EdgeInsetsDirectional|\.arb\b'

--- a/evals/tests/layered-architecture.yaml
+++ b/evals/tests/layered-architecture.yaml
@@ -61,6 +61,7 @@
     # routing
     - type: skill-used
       value: 'vgv-ai-flutter-plugin:layered-architecture'
+      weight: 3
     # mechanical
     - type: regex
       value: 'packages/'
@@ -117,6 +118,7 @@
     # routing
     - type: skill-used
       value: 'vgv-ai-flutter-plugin:layered-architecture'
+      weight: 3
     # judged
     - type: llm-rubric
       value: >-
@@ -158,6 +160,7 @@
     # routing
     - type: skill-used
       value: 'vgv-ai-flutter-plugin:layered-architecture'
+      weight: 3
     # mechanical
     - type: regex
       value: 'class WeatherRepository'
@@ -201,6 +204,7 @@
     # routing
     - type: skill-used
       value: 'vgv-ai-flutter-plugin:layered-architecture'
+      weight: 3
     # judged
     - type: llm-rubric
       value: >-
@@ -226,6 +230,7 @@
     # routing
     - type: skill-used
       value: 'vgv-ai-flutter-plugin:layered-architecture'
+      weight: 3
     # judged
     - type: llm-rubric
       value: >-
@@ -253,6 +258,7 @@
     # routing
     - type: skill-used
       value: 'vgv-ai-flutter-plugin:layered-architecture'
+      weight: 3
     # mechanical
     - type: regex
       value: 'MultiRepositoryProvider|RepositoryProvider'
@@ -287,6 +293,7 @@
     # routing
     - type: not-skill-used
       value: 'vgv-ai-flutter-plugin:layered-architecture'
+      weight: 3
     # mechanical
     - type: not-regex
       value: 'packages/|_api_client|_repository|RepositoryProvider'

--- a/evals/tests/license-compliance.yaml
+++ b/evals/tests/license-compliance.yaml
@@ -60,6 +60,7 @@
     # routing
     - type: skill-used
       value: 'vgv-ai-flutter-plugin:license-compliance'
+      weight: 3
     # mechanical
     # Both surface forms of the same thing: the `packages_check_licenses` MCP tool and
     # `very_good packages check licenses`. Asserting only one would test syntax.
@@ -110,6 +111,7 @@
     # routing
     - type: skill-used
       value: 'vgv-ai-flutter-plugin:license-compliance'
+      weight: 3
     # mechanical
     - type: regex
       value: 'packages[ _]check[ _]licenses'
@@ -161,6 +163,7 @@
     # routing
     - type: skill-used
       value: 'vgv-ai-flutter-plugin:license-compliance'
+      weight: 3
     # mechanical
     # The report skeleton, graded twice: heading and summary line. Either alone is one
     # formatting slip away from a false negative.
@@ -214,6 +217,7 @@
     # routing
     - type: skill-used
       value: 'vgv-ai-flutter-plugin:license-compliance'
+      weight: 3
     # mechanical
     - type: regex
       value: 'packages[ _]check[ _]licenses'
@@ -251,6 +255,7 @@
     # routing
     - type: skill-used
       value: 'vgv-ai-flutter-plugin:license-compliance'
+      weight: 3
     # mechanical
     - type: icontains
       value: 'all rights reserved'
@@ -287,6 +292,7 @@
     # routing
     - type: not-skill-used
       value: 'vgv-ai-flutter-plugin:license-compliance'
+      weight: 3
     # mechanical
     - type: not-regex
       value: '[Ll]icense|copyleft|\bMIT\b|\bGPL|\bBSD\b|Apache-2'

--- a/evals/tests/material-theming.yaml
+++ b/evals/tests/material-theming.yaml
@@ -65,6 +65,7 @@
     # routing
     - type: skill-used
       value: 'vgv-ai-flutter-plugin:material-theming'
+      weight: 3
     # mechanical
     - type: regex
       value: 'abstract class AppColors'
@@ -129,6 +130,7 @@
     # routing
     - type: skill-used
       value: 'vgv-ai-flutter-plugin:material-theming'
+      weight: 3
     # mechanical
     # Colors and text styles are graded twice mechanically and once by rubric: a
     # response that fixes the color and keeps the TextStyle literal would clear 0.8.
@@ -181,6 +183,7 @@
     # routing
     - type: skill-used
       value: 'vgv-ai-flutter-plugin:material-theming'
+      weight: 3
     # mechanical
     - type: regex
       value: 'class AppSpacing'
@@ -236,6 +239,7 @@
     # routing
     - type: skill-used
       value: 'vgv-ai-flutter-plugin:material-theming'
+      weight: 3
     # mechanical
     - type: regex
       value: 'inputDecorationTheme'
@@ -291,6 +295,7 @@
     # routing
     - type: skill-used
       value: 'vgv-ai-flutter-plugin:material-theming'
+      weight: 3
     # mechanical
     - type: regex
       value: 'Theme\.of\(context\)\.colorScheme'
@@ -330,6 +335,7 @@
     # routing
     - type: not-skill-used
       value: 'vgv-ai-flutter-plugin:material-theming'
+      weight: 3
     # mechanical
     - type: not-regex
       value: 'ThemeData|ColorScheme|colorScheme|textTheme|Theme\.of\('

--- a/evals/tests/navigation.yaml
+++ b/evals/tests/navigation.yaml
@@ -61,6 +61,7 @@
     # routing
     - type: skill-used
       value: 'vgv-ai-flutter-plugin:navigation'
+      weight: 3
     # mechanical
     - type: regex
       value: '@TypedGoRoute<'
@@ -95,6 +96,7 @@
     # routing
     - type: skill-used
       value: 'vgv-ai-flutter-plugin:navigation'
+      weight: 3
     # judged
     - type: llm-rubric
       value: >-
@@ -133,6 +135,7 @@
     # routing
     - type: skill-used
       value: 'vgv-ai-flutter-plugin:navigation'
+      weight: 3
     # mechanical
     # "Use @TypedGoRoute annotations for type-safe routes — never raw string paths in
     # route definitions."
@@ -169,6 +172,7 @@
     # routing
     - type: skill-used
       value: 'vgv-ai-flutter-plugin:navigation'
+      weight: 3
     # mechanical
     - type: regex
       value: 'redirect'
@@ -201,6 +205,7 @@
     # routing
     - type: skill-used
       value: 'vgv-ai-flutter-plugin:navigation'
+      weight: 3
     # mechanical
     # The whole go family counts, and so does the whole push family: the skill emits
     # context.goNamed(...) here, which `\.go\(` alone does not match.
@@ -229,6 +234,7 @@
     # routing
     - type: skill-used
       value: 'vgv-ai-flutter-plugin:navigation'
+      weight: 3
     # mechanical
     - type: regex
       value: 'Mock.*GoRouter|GoRouter.*Mock'
@@ -255,6 +261,7 @@
     # routing
     - type: not-skill-used
       value: 'vgv-ai-flutter-plugin:navigation'
+      weight: 3
     # mechanical
     - type: not-regex
       value: 'GoRoute|go_router|context\.go|ShellRoute'

--- a/evals/tests/static-security.yaml
+++ b/evals/tests/static-security.yaml
@@ -71,6 +71,7 @@
     # routing
     - type: skill-used
       value: 'vgv-ai-flutter-plugin:static-security'
+      weight: 3
     # judged
     # The prohibition itself. SKILL.md: --dart-define / String.fromEnvironment "are
     # not a safe alternative to backend-served secrets."
@@ -141,6 +142,7 @@
     # routing
     - type: skill-used
       value: 'vgv-ai-flutter-plugin:static-security'
+      weight: 3
     # mechanical
     # The middle tier is the tell. No trailing `\b` on Warning so a "Warnings"
     # heading counts; `\bMedium\b` will not fire on `Durations.medium2`-style text.
@@ -195,6 +197,7 @@
     # routing
     - type: skill-used
       value: 'vgv-ai-flutter-plugin:static-security'
+      weight: 3
     # mechanical
     - type: regex
       value: 'dart_crypt'
@@ -241,6 +244,7 @@
     # routing
     - type: skill-used
       value: 'vgv-ai-flutter-plugin:static-security'
+      weight: 3
     # mechanical
     # SKILL.md: "Use package:formz for all form validation. Define a FormzInput
     # subclass per field."
@@ -276,6 +280,7 @@
     # routing
     - type: skill-used
       value: 'vgv-ai-flutter-plugin:static-security'
+      weight: 3
     # mechanical
     # references/crypto.md: "Use package:local_auth ... Do not invoke platform
     # channels directly."
@@ -324,6 +329,7 @@
     # routing
     - type: skill-used
       value: 'vgv-ai-flutter-plugin:static-security'
+      weight: 3
     # mechanical
     # SKILL.md: "Scan pubspec.lock with osv-scanner before every release". The
     # lockfile target specifically is the part the bare model does not produce.
@@ -331,8 +337,12 @@
       value: 'osv-scanner'
     - type: regex
       value: 'pubspec\.lock'
+    # Either prefix. The pasted pubspec depends on Flutter, and SKILL.md's own verify
+    # guidance says to match the tool to the package, so `flutter pub outdated` is the
+    # correct spelling here even though the checklist writes the `dart` form. Pinning
+    # this to `dart` graded the prefix rather than the step.
     - type: regex
-      value: 'dart pub outdated'
+      value: '(dart|flutter) pub outdated'
     # judged
     - type: llm-rubric
       value: >-
@@ -357,6 +367,7 @@
     # routing
     - type: not-skill-used
       value: 'vgv-ai-flutter-plugin:static-security'
+      weight: 3
     # mechanical
     - type: not-regex
       value: 'flutter_secure_storage|FormzInput|Random\.secure|osv-scanner|local_auth'

--- a/evals/tests/testing.yaml
+++ b/evals/tests/testing.yaml
@@ -69,6 +69,7 @@
     # routing
     - type: skill-used
       value: 'vgv-ai-flutter-plugin:testing'
+      weight: 3
     # mechanical
     - type: regex
       value: 'class _Mock[A-Za-z]+ extends Mock implements'
@@ -126,6 +127,7 @@
     # routing
     - type: skill-used
       value: 'vgv-ai-flutter-plugin:testing'
+      weight: 3
     # mechanical
     - type: icontains
       value: 'mocktail'
@@ -160,6 +162,7 @@
     # routing
     - type: skill-used
       value: 'vgv-ai-flutter-plugin:testing'
+      weight: 3
     # mechanical
     - type: regex
       value: 'testWidgets'
@@ -198,6 +201,7 @@
     # routing
     - type: skill-used
       value: 'vgv-ai-flutter-plugin:testing'
+      weight: 3
     # judged
     - type: llm-rubric
       value: >-
@@ -224,6 +228,7 @@
     # routing
     - type: skill-used
       value: 'vgv-ai-flutter-plugin:testing'
+      weight: 3
     # mechanical
     - type: regex
       value: 'TestTag'
@@ -249,6 +254,7 @@
     # routing
     - type: not-skill-used
       value: 'vgv-ai-flutter-plugin:testing'
+      weight: 3
     # mechanical
     - type: not-regex
       value: 'testWidgets|pumpApp|mocktail|setUp\('

--- a/evals/tests/ui-package.yaml
+++ b/evals/tests/ui-package.yaml
@@ -69,6 +69,7 @@
     # routing
     - type: skill-used
       value: 'vgv-ai-flutter-plugin:ui-package'
+      weight: 3
     # mechanical
     # The template name is the whole point of this case: it appears only in this
     # SKILL.md, and create-project's template list does not contain it either.
@@ -111,6 +112,7 @@
     # routing
     - type: skill-used
       value: 'vgv-ai-flutter-plugin:ui-package'
+      weight: 3
     # mechanical
     # One widget per file, named after the widget in snake_case, under src/. `\w`
     # covers underscores, so app_badge.dart and app_unread_badge.dart both match.
@@ -164,6 +166,7 @@
     # routing
     - type: skill-used
       value: 'vgv-ai-flutter-plugin:ui-package'
+      weight: 3
     # mechanical
     # The documented alternative, graded mechanically alongside the first rubric.
     - type: regex
@@ -211,6 +214,7 @@
     # routing
     - type: skill-used
       value: 'vgv-ai-flutter-plugin:ui-package'
+      weight: 3
     # mechanical
     - type: regex
       value: 'ThemeExtension<'
@@ -267,6 +271,7 @@
     # routing
     - type: skill-used
       value: 'vgv-ai-flutter-plugin:ui-package'
+      weight: 3
     # mechanical
     - type: regex
       value: 'pumpApp'
@@ -305,6 +310,7 @@
     # routing
     - type: skill-used
       value: 'vgv-ai-flutter-plugin:ui-package'
+      weight: 3
     # mechanical
     # The barrel path, without a `package:` prefix: promptfoo reads any assertion value
     # starting with `package:` as an npm-hosted assertion and errors the whole case.
@@ -343,6 +349,7 @@
     # routing
     - type: not-skill-used
       value: 'vgv-ai-flutter-plugin:ui-package'
+      weight: 3
     # mechanical
     - type: not-regex
       value: 'ThemeExtension|app_ui_package|[Ww]idgetbook|pumpApp|barrel file'

--- a/evals/tests/very-good-analysis-upgrade.yaml
+++ b/evals/tests/very-good-analysis-upgrade.yaml
@@ -66,6 +66,7 @@
     # routing
     - type: skill-used
       value: 'vgv-ai-flutter-plugin:very-good-analysis-upgrade'
+      weight: 3
     # mechanical
     # The version-resolution recipe is verbatim in SKILL.md. Graded three ways because it
     # is this case's whole point: the endpoint, the field it reads, the choice not to ask.
@@ -123,6 +124,7 @@
     # routing
     - type: skill-used
       value: 'vgv-ai-flutter-plugin:very-good-analysis-upgrade'
+      weight: 3
     # mechanical
     # Fails if the model honored "pin it exactly" and wrote `very_good_analysis: 10.0.0`.
     - type: regex
@@ -201,6 +203,7 @@
     # routing
     - type: skill-used
       value: 'vgv-ai-flutter-plugin:very-good-analysis-upgrade'
+      weight: 3
     # mechanical
     # One regex covers both style lints: prefer_const_constructors wants the `const`,
     # require_trailing_commas wants the comma, and both land on the same line.
@@ -261,6 +264,7 @@
     # routing
     - type: skill-used
       value: 'vgv-ai-flutter-plugin:very-good-analysis-upgrade'
+      weight: 3
     # mechanical
     # At least two separate pub get invocations. SKILL.md, Tips: "`pub get` must be run
     # per-package." A single root-level pub get fails this.
@@ -324,6 +328,7 @@
     # routing
     - type: skill-used
       value: 'vgv-ai-flutter-plugin:very-good-analysis-upgrade'
+      weight: 3
     # judged
     - type: llm-rubric
       value: >-
@@ -368,6 +373,7 @@
     # routing
     - type: skill-used
       value: 'vgv-ai-flutter-plugin:very-good-analysis-upgrade'
+      weight: 3
     # judged
     - type: llm-rubric
       value: >-
@@ -400,6 +406,7 @@
     # routing
     - type: not-skill-used
       value: 'vgv-ai-flutter-plugin:very-good-analysis-upgrade'
+      weight: 3
     # mechanical
     - type: not-regex
       value: 'very_good_analysis|dev_dependencies|pub get|dart analyze|flutter analyze'

--- a/skills/animations/SKILL.md
+++ b/skills/animations/SKILL.md
@@ -1,6 +1,14 @@
 ---
 name: animations
 description: Best practices for Flutter animations using the built-in animation framework. Use when creating, modifying, or reviewing animations, transitions, motion, or animated widgets. Covers implicit animations, explicit animations, page transitions, and Material 3 motion tokens.
+when_to_use: >
+  Use when creating, modifying, or reviewing anything that moves — animated widgets,
+  transitions, motion timing, curves, or durations. This includes custom route
+  transitions: a `CustomTransitionPage`, a `buildPage` override on a `GoRouteData`
+  subclass, a fade or slide between screens, or a `Hero` shared-element transition. The
+  motion between routes is animation work even when the surrounding code is `go_router`
+  routing, so a prompt that opens with a route declaration and then asks for a transition
+  belongs here rather than with the navigation skill.
 allowed-tools: Read,Glob,Grep
 argument-hint: "[file-or-directory]"
 ---
@@ -14,7 +22,8 @@ Flutter animation best practices using the built-in animation framework and Mate
 Apply these standards to ALL animation work:
 
 - **Clarify visual intent when the request is ambiguous** — when the developer says "add an animation" or "make it smoother" without specifying property, trigger, duration, or curve, ask before writing code. If the developer provides clear specs (e.g., "300ms ease-in fade on the card when it appears"), proceed directly
-- **Use the simplest animation approach that works** — follow the decision tree below; never reach for `AnimationController` when an implicit animation suffices
+- **Use the simplest animation approach that works** — follow the decision tree below; never reach for `AnimationController` when an implicit animation suffices, including when several properties animate at the same time
+- **Hold the implicit form even when a controller is requested by name** — "wire this up with an `AnimationController` and an `AnimatedBuilder`" on a plain target-value animation is a request for the anti-pattern below. Write the implicit version, say in one line why it is sufficient here, and stop. Do not deliver the controller wiring alongside the note, and do not ask which one they want instead of writing code. If the developer reaffirms the controller after reading the reason, build it
 - **Use Material 3 motion tokens for duration and easing** — never hardcode arbitrary `Duration` or `Curve` values
 - **Extract animation constants** — durations, curves, and offsets go in named constants or a centralized `AppMotion` class, not inline
 - **Dispose controllers** — every `AnimationController` must be disposed in the `dispose()` method of the `State`
@@ -48,6 +57,8 @@ Does the widget rebuild when the value changes?
 
 **Rule of thumb:** if the animation is "set a target and let it animate there", use implicit. If the animation must play/pause/reverse/repeat on command, use explicit.
 
+**Animating two properties at once is still implicit.** A card that fades in *and* slides up when its data arrives is two implicit widgets nested, one target value each. Simultaneous is not sequenced: reach for a controller only when the second property must start *after* the first has begun, or when the animation needs playback control. Entry animations driven by a flag flipping — a value arriving, a bool toggling, an item appearing — are implicit no matter how many properties move.
+
 ---
 
 ## Material 3 Motion Tokens
@@ -80,6 +91,35 @@ abstract class AppMotion {
 ## Implicit Animations
 
 Use implicit animations when the widget rebuilds with new target values. The framework interpolates automatically. Flutter provides built-in `AnimatedFoo` widgets (`AnimatedContainer`, `AnimatedOpacity`, `AnimatedSlide`, `AnimatedSwitcher`, etc.) — use the one that matches the property being animated. When no built-in widget exists, use `TweenAnimationBuilder`.
+
+Compose one `AnimatedFoo` per property when several move together. This is the entry-animation shape — a widget hidden until its data arrives, then fading in and sliding into place:
+
+```dart
+class SummaryCard extends StatelessWidget {
+  const SummaryCard({required this.summary, super.key});
+
+  final Summary? summary;
+
+  @override
+  Widget build(BuildContext context) {
+    final hasData = summary != null;
+
+    return AnimatedOpacity(
+      opacity: hasData ? 1 : 0,
+      duration: Durations.medium2,
+      curve: Easing.standard,
+      child: AnimatedSlide(
+        offset: hasData ? Offset.zero : const Offset(0, 0.1),
+        duration: Durations.medium2,
+        curve: Easing.emphasizedDecelerate,
+        child: Card(child: _SummaryContents(summary: summary)),
+      ),
+    );
+  }
+}
+```
+
+No `StatefulWidget`, no controller, no ticker, no `dispose`. Both properties animate off the same rebuild.
 
 ---
 
@@ -158,9 +198,11 @@ class _MyWidgetState extends State<MyWidget>
 
 See [references/explicit-animations.md](references/explicit-animations.md) for `didUpdateWidget` patterns, constructor injection for testable controllers, and transition widget vs `AnimatedBuilder` guidance.
 
-### Chained Animations with Intervals
+### Staggered Animations with Intervals
 
-Use `Interval` inside `CurvedAnimation` to sequence animations on a single controller:
+Use `Interval` inside `CurvedAnimation` to **stagger** animations on a single controller — the slide starts partway through the fade rather than alongside it. The overlapping `Interval` ranges are the whole point of this pattern.
+
+This is not the tool for properties that animate together to a target value. A fade and a slide that both run on the same rebuild are two implicit widgets, not a controller with two intervals:
 
 ```dart
 late final Animation<double> _fadeAnimation = CurvedAnimation(
@@ -333,6 +375,8 @@ AnimatedOpacity(
   child: child,
 )
 ```
+
+The request often arrives pre-shaped as the bad form: "set it up with an `AnimationController` and an `AnimatedBuilder` inside a `StatefulWidget` so it is wired properly." On a fade driven by a bool, that is the anti-pattern above written out as a request. Answer with the `AnimatedOpacity` version, give the one-line reason, and leave the controller unwritten — a compliant snippet with a note recommending the simpler form still ships the boilerplate.
 
 ---
 

--- a/skills/animations/SKILL.md
+++ b/skills/animations/SKILL.md
@@ -286,7 +286,7 @@ Rules for Hero:
 
 - **Do not animate `width`, `height`, or `padding` on complex layouts** — triggers expensive layout recalculations every frame
 - **Do not wrap entire screens in `AnimatedBuilder`** — only wrap the subtree that changes
-- **Do not create multiple `AnimationController` instances for animations that share timing** — use `Interval` on a single controller
+- **Do not create multiple `AnimationController` instances for animations that share timing** — use `Interval` on a single controller. This applies once the animation already needs a controller; properties that animate to a target on the same rebuild are composed implicit widgets, not one controller with intervals
 
 ---
 

--- a/skills/animations/SKILL.md
+++ b/skills/animations/SKILL.md
@@ -2,13 +2,9 @@
 name: animations
 description: Best practices for Flutter animations using the built-in animation framework. Use when creating, modifying, or reviewing animations, transitions, motion, or animated widgets. Covers implicit animations, explicit animations, page transitions, and Material 3 motion tokens.
 when_to_use: >
-  Use when creating, modifying, or reviewing anything that moves — animated widgets,
-  transitions, motion timing, curves, or durations. This includes custom route
-  transitions: a `CustomTransitionPage`, a `buildPage` override on a `GoRouteData`
-  subclass, a fade or slide between screens, or a `Hero` shared-element transition. The
-  motion between routes is animation work even when the surrounding code is `go_router`
-  routing, so a prompt that opens with a route declaration and then asks for a transition
-  belongs here rather than with the navigation skill.
+  Also use for custom route transitions — `CustomTransitionPage`, a `buildPage` override on
+  a `GoRouteData` subclass, or a `Hero` transition. Motion between routes is animation work
+  even when the surrounding code is `go_router`.
 allowed-tools: Read,Glob,Grep
 argument-hint: "[file-or-directory]"
 ---

--- a/skills/dart-flutter-sdk-upgrade/SKILL.md
+++ b/skills/dart-flutter-sdk-upgrade/SKILL.md
@@ -31,11 +31,13 @@ version bumps, no test changes.
 
 Apply these standards to ALL SDK upgrade work:
 
-- **Flutter and Dart versions differ** — always look up the Dart version bundled with the target Flutter release from <https://docs.flutter.dev/install/archive>
+- **Flutter and Dart versions differ** — a Flutter release ships a Dart SDK whose version number is unrelated to it, and the pubspec `sdk:` constraint takes the Dart number, never the Flutter one. Look the pairing up in the release archive at <https://docs.flutter.dev/install/archive>
+- **Never state a bundled Dart version from memory** — not from recall, not by inference from the Flutter number, and not from an example in this file. Either the user supplied the Dart version, or you read it off the archive, or you ask. There is no fourth source
 - **Flutter CI uses `MAJOR.MINOR.x`** — no caret, `.x` wildcard resolves to latest patch
 - **Dart CI uses exact patch** — `MAJOR.MINOR.PATCH`, no caret, no wildcard
 - **pubspec pins exact patch** — use `^MAJOR.MINOR.PATCH` with the specific patch version
-- **Pure Dart packages** — use the Dart version directly, no Flutter mapping needed
+- **Pure Dart packages** — use the Dart version directly, no Flutter mapping needed. The CI key is `dart_sdk` in `dart_package.yml`, not `flutter_version` in `flutter_package.yml`, and the environment block gets `sdk:` with no `flutter:` line beside it
+- **Write the CI block even without the file** — the reusable workflow and its version key are determined by the package type, so a workflow you have not seen is still a known shape. Produce the `with:` block from the CI workflows section below and name the file it belongs in rather than asking for the file first
 - **Verify with `pub get` and `analyze`** — don't silently resolve conflicts
 - **Decline out-of-scope edits, don't caveat them** — when asked to also bump a
   dependency, fix a lint, or change code, do not produce that edit at all. Deliver the
@@ -45,9 +47,10 @@ Apply these standards to ALL SDK upgrade work:
 
 ## 0. Resolve target version
 
-Flutter bundles a specific Dart release — their version numbers do **not** match. For
-example, Flutter 3.41.0 ships with Dart 3.11.0. You must look up the correct Dart version
-for the target Flutter release before editing any files.
+Flutter bundles a specific Dart release, and the two version numbers are unrelated. A bump to
+Flutter 3.35.5 does not make the Dart constraint `^3.35.5`, and the Dart number cannot be
+derived from the Flutter number by any rule. Every SDK upgrade therefore starts with two
+versions, not one: the Flutter release being targeted, and the Dart release it ships.
 
 **How to find the Dart version:**
 
@@ -55,12 +58,17 @@ for the target Flutter release before editing any files.
 2. Find the target Flutter stable release
 3. Note the Dart version listed alongside it
 
-The target version comes from `$ARGUMENTS` (e.g. `3.41.0`) when the user supplied one. If
-`$ARGUMENTS` is empty, look up the latest Flutter stable release from that same page. For pure
-Dart packages (no Flutter dependency), the Dart version is whatever `$ARGUMENTS` specifies or
-the latest stable — no Flutter mapping needed.
+The Flutter target comes from `$ARGUMENTS` when the user supplied one. If `$ARGUMENTS` is
+empty, take the latest Flutter stable from that same page. For pure Dart packages, no mapping
+is involved: the Dart version is whatever `$ARGUMENTS` specifies or the latest Dart stable.
 
-Confirm both resolved versions with the user before editing files.
+**When the archive is out of reach**, which is the common case in a session with no network
+access, do not fill the gap from memory. A recalled pairing is wrong often enough to break
+`pub get`, and it is wrong silently — the constraint looks plausible in the diff. Say the Dart
+version has to come off the archive, name the page as the source, and ask the user to confirm
+it. If the user already supplied both numbers, use them as given and say which is which.
+
+State both resolved versions and get confirmation before editing any file.
 
 ---
 
@@ -92,6 +100,27 @@ with:
 If a file uses `flutter_channel: stable` instead of a pinned version,
 pin the version — VGV always pins Flutter versions in CI workflows.
 
+### When the workflow file is not in hand
+
+A VGV package's CI is one job calling one of the two reusable workflows above, so the block that
+needs changing is fully determined by the package type. When the workflow lives in another
+checkout, or the user described it instead of pasting it, write the `with:` block from the
+shapes above rather than stalling on the file. Say which workflow and which key you are
+targeting — `dart_package.yml` with `dart_sdk` for a pure Dart package, `flutter_package.yml`
+with `flutter_version` for a Flutter one — and present it as the block to merge into the
+existing job.
+
+Two things are not invented that way. Do not fabricate the surrounding `name:`, `on:` or `jobs:`
+keys when you have not seen them, and do not guess a version number. Show the `with:` block and
+name the file it belongs in.
+
+```yaml
+# Pure Dart package, target Dart 3.11.0 — the block to merge into your existing job
+uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/dart_package.yml@v1
+with:
+  dart_sdk: "3.11.0"
+```
+
 ---
 
 ## 2. `pubspec.yaml` environment constraints
@@ -103,9 +132,14 @@ patch version — the one the user specifies or the current stable at the time o
 
 ```yaml
 environment:
-  sdk: ^3.11.0 # ← Dart version bundled with the target Flutter release
-  flutter: ^3.41.0 # ← Flutter version
+  sdk: ^DART_VERSION # ← the Dart version the target Flutter release ships
+  flutter: ^FLUTTER_VERSION # ← the target Flutter release itself
 ```
+
+The two placeholders are deliberate. Filling them in requires the archive lookup from step 0,
+and the numbers are never the same: for a bump to Flutter 3.35.5 the `flutter:` constraint is
+`^3.35.5` and the `sdk:` constraint is whatever Dart version the archive lists beside 3.35.5.
+Writing the Flutter number into `sdk:` is the single most common error in this change.
 
 **Pure Dart package** (no Flutter SDK dependency):
 
@@ -145,14 +179,13 @@ Refuse the extras outright. A caveat attached to the forbidden edit is not a ref
 writing the new dependency version into the pubspec while noting that it doesn't belong
 there still ships the mixed PR.
 
-So when the request is "bump to Flutter 3.41.0 (Dart 3.11.0), raise the `http`
-constraint, and fix the two analyzer warnings", the pubspec you return changes the
-environment block and nothing else:
+So when the request is "bump to the new Flutter, raise the `http` constraint, and fix the two
+analyzer warnings", the pubspec you return changes the environment block and nothing else:
 
 ```yaml
 environment:
-  sdk: ^3.11.0 # ← changed
-  flutter: ^3.41.0 # ← changed
+  sdk: ^DART_VERSION # ← changed, Dart version from the archive
+  flutter: ^FLUTTER_VERSION # ← changed, the target Flutter release
 
 dependencies:
   flutter:
@@ -185,11 +218,14 @@ git diff HEAD --name-only
 Suggested commit/PR message:
 
 ```text
-chore: bump Flutter to 3.41.0 / Dart to 3.11.0
+chore: bump Flutter to FLUTTER_VERSION / Dart to DART_VERSION
 
-- Update flutter_version in .github/workflows/ to 3.41.x (CI resolves latest patch)
-- Update dart_sdk in .github/workflows/ to 3.11.0 (exact patch)
+- Update flutter_version in .github/workflows/ to MAJOR.MINOR.x (CI resolves latest patch)
+- Update dart_sdk in .github/workflows/ to the exact Dart patch
 - Update environment sdk/flutter constraints in pubspec.yaml
 
 No logic or code changes.
 ```
+
+Both numbers appear in the subject line because a reviewer scanning history needs to see which
+Dart release came with the bump. Fill them from step 0, never from recall.

--- a/skills/dart-flutter-sdk-upgrade/SKILL.md
+++ b/skills/dart-flutter-sdk-upgrade/SKILL.md
@@ -132,8 +132,8 @@ patch version — the one the user specifies or the current stable at the time o
 
 ```yaml
 environment:
-  sdk: ^DART_VERSION # ← the Dart version the target Flutter release ships
-  flutter: ^FLUTTER_VERSION # ← the target Flutter release itself
+  sdk: ^<dart-version> # ← the Dart version the target Flutter release ships
+  flutter: ^<flutter-version> # ← the target Flutter release itself
 ```
 
 The two placeholders are deliberate. Filling them in requires the archive lookup from step 0,
@@ -188,8 +188,8 @@ analyzer warnings", the pubspec you return changes the environment block and not
 
 ```yaml
 environment:
-  sdk: ^DART_VERSION # ← changed, Dart version from the archive
-  flutter: ^FLUTTER_VERSION # ← changed, the target Flutter release
+  sdk: ^<dart-version> # ← changed, Dart version from the archive
+  flutter: ^<flutter-version> # ← changed, the target Flutter release
 
 dependencies:
   flutter:
@@ -222,7 +222,7 @@ git diff HEAD --name-only
 Suggested commit/PR message:
 
 ```text
-chore: bump Flutter to FLUTTER_VERSION / Dart to DART_VERSION
+chore: bump Flutter to <flutter-version> / Dart to <dart-version>
 
 - Update flutter_version in .github/workflows/ to MAJOR.MINOR.x (CI resolves latest patch)
 - Update dart_sdk in .github/workflows/ to the exact Dart patch

--- a/skills/dart-flutter-sdk-upgrade/SKILL.md
+++ b/skills/dart-flutter-sdk-upgrade/SKILL.md
@@ -169,6 +169,10 @@ clashes with the new one, then hand the decision back to the user: raising that
 dependency is its own PR, not part of this one. If `analyze` surfaces new errors
 introduced by the SDK bump, report them rather than fixing them in this PR.
 
+See [references/version-conflicts.md](references/version-conflicts.md) for reading version
+solving output, the three shapes a conflict takes, tracing a transitive blocker, and the
+report format to hand back.
+
 ---
 
 ## 4. Out-of-scope requests

--- a/skills/dart-flutter-sdk-upgrade/references/version-conflicts.md
+++ b/skills/dart-flutter-sdk-upgrade/references/version-conflicts.md
@@ -1,0 +1,76 @@
+# Version Solving Conflicts
+
+`pub get` failing after an SDK bump is the normal outcome, not a sign the bump was wrong. This
+file covers reading the failure and reporting it. The decision itself does not change: name the
+conflict and hand it back, never resolve it by moving another dependency.
+
+## Reading the output
+
+Version solving output names the constraint it could not satisfy. Read it from the bottom up —
+the last line is usually the actual conflict, and the lines above it are the search path pub
+took to get there.
+
+```text
+Because acme_app depends on very_good_analysis >=6.0.0 <7.0.0 which requires SDK version
+>=3.5.0 <3.9.0, version solving failed.
+```
+
+Three pieces matter, and a useful report has all three:
+
+1. **The blocking package** and the version pub resolved or tried to resolve
+2. **The constraint it carries** that clashes, which is often an SDK constraint rather than a
+   dependency version
+3. **The new constraint** from this bump that it clashes with
+
+From the example above: `very_good_analysis` at `^6.0.0` caps the Dart SDK below `3.9.0`, and
+the bump asks for a Dart SDK at or above that. That is the whole finding.
+
+## The three shapes
+
+| Shape                              | What the output shows                                                   | Who owns the fix                                          |
+| ---------------------------------- | ----------------------------------------------------------------------- | --------------------------------------------------------- |
+| Direct dependency caps the SDK     | A package in `dependencies` or `dev_dependencies` requires an older SDK | The user, in a dependency-bump PR of its own              |
+| Transitive dependency caps the SDK | The named package is not in any pubspec                                 | The user, by raising whichever direct dependency pulls it |
+| No published version satisfies     | Every version of a package is rejected                                  | The package's maintainer, so the bump is blocked upstream |
+
+The middle one is the one most often misread. When the blocking package is nowhere in the
+pubspec, do not add a constraint for it to force resolution. Trace which direct dependency
+brought it in and report that instead:
+
+```bash
+flutter pub deps --style=tree   # or: dart pub deps --style=tree
+```
+
+## What to report
+
+Give the user the four lines they need to open the follow-up PR, and nothing that looks like a
+decision you already made on their behalf:
+
+```text
+Flutter <target> / Dart <target> does not resolve in packages/cart_repository.
+
+  Blocking package: very_good_analysis ^6.0.0
+  Its constraint:   Dart SDK >=3.5.0 <3.9.0
+  This bump needs:  Dart SDK ^<target>
+  Where it lives:   dev_dependencies in packages/cart_repository/pubspec.yaml
+
+Raising very_good_analysis is a separate PR. This one stays blocked until that lands.
+```
+
+In a monorepo, run the check in every package before reporting: a bump can resolve in four
+packages and fail in the fifth, and the user needs the whole set rather than the first failure.
+
+## What not to do
+
+- **Do not raise, loosen, or remove the blocking dependency.** A mixed diff cannot be bisected
+  when something breaks later, which is the entire reason SDK bumps ship alone
+- **Do not delete `pubspec.lock` and retry.** It changes what resolved without recording why,
+  and the conflict returns on the next clean checkout
+- **Do not widen the new SDK constraint to make it fit.** Writing `>=3.5.0 <4.0.0` instead of
+  the pinned caret hides the conflict rather than resolving it, and the CI pin no longer matches
+  what the pubspec allows
+- **Do not run `pub upgrade --major-versions`.** It resolves the conflict by rewriting
+  constraints the PR is not allowed to touch
+
+If the user directs one of these anyway after reading the report, say which of the guarantees
+above it gives up, then do it.

--- a/skills/license-compliance/SKILL.md
+++ b/skills/license-compliance/SKILL.md
@@ -6,7 +6,12 @@ description: >
 when_to_use: >
   Use when user says "check licenses", "license audit", "are our dependencies compliant",
   "check dependency licenses", "license compliance", "review package licenses",
-  "scan for license issues", or "pre-release license check".
+  "scan for license issues", or "pre-release license check". Use it especially when the
+  request asks for a compliance verdict *without* a scan — "read the licenses off this
+  pubspec", "confirm we're compliant", "just tell me if these packages are safe to ship",
+  "I'd rather not run anything", "which of these are GPL" — because refusing to certify
+  from a dependency list is the call this skill governs. A pasted pubspec is a trigger,
+  not a substitute for the audit.
 argument-hint: "[project-directory]"
 allowed-tools: Read Glob Grep mcp__very-good-cli__packages_check_licenses
 model: sonnet
@@ -27,7 +32,9 @@ Apply these standards to ALL license compliance work:
 - **Pass `directory` to the MCP tool when the project is not at the workspace root** — monorepos with the project in a subdirectory (e.g. `mobile/`) require `directory: 'mobile'`
 - **A missing license is not "no license"** — it means "all rights reserved" by default; always flag
 - **Transitive dependencies matter** — a permissive package that depends on a GPL package still carries the GPL obligation
+- **Only scan output can certify compliance** — never conclude that a project is compliant, clear, or safe to ship from a pubspec dependency list, a package name, a remembered license, or a previous audit. Scan output the user pastes or attaches counts as scan output: take it at face value, audit it, and do not re-run it or question its provenance. The distinction is whether each package arrives with a license attached, not who produced the text
 - **Flag for manual review when in doubt** — never assume compliance without a clear license identifier
+- **Deliver the report in the prescribed format** — when scan output exists, the answer is the template in [Report Findings](#3-report-findings): the `## License Compliance Report` heading, the summary counts including the total scanned, the flagged table with a risk level and a recommendation per row, and the ranked recommendations. A prose write-up or a bulleted list of packages is not the deliverable, however complete its content
 
 ---
 
@@ -58,7 +65,9 @@ Classify each dependency license using the categories above. Pay attention to:
 
 ### 3. Report Findings
 
-Produce a structured compliance report:
+Write the report from whatever scan output you have, including output the user pasted into the request. That text is the input to this step, not something to verify first. Report what it says, flag what it flags, and note as its own line that transitive dependencies outside the scanned set are not covered — a caveat inside the report, never a reason to withhold the report.
+
+The report below is a fixed format, not an illustration. Copy the four headings verbatim, keep the `- Total dependencies scanned: N` line even when nothing is flagged, and keep all four table columns including `Recommendation` as its own column. A reader attaches this to a release ticket and diffs it against the previous audit, which only works when every run has the same shape.
 
 ```markdown
 ## License Compliance Report
@@ -80,3 +89,23 @@ All other dependencies use permissive licenses (MIT, BSD, Apache 2.0).
 1. [Most urgent action]
 2. [Next action]
 ```
+
+Three ways this comes out wrong, all of which fail the format: prose paragraphs instead of the headings, flagged packages as a bulleted list instead of table rows, and a recommendation folded into the risk cell instead of standing as its own column. One row per flagged package, one recommendation per row.
+
+---
+
+## When the Request Is to Skip the Scan
+
+This section applies to one situation only: the request supplies package **names** with no licenses attached, usually a pubspec `dependencies` block, and asks for a verdict anyway. If each package arrives with a license beside it, that is scan output and the answer is the report in step 3 — go there instead. Refusing to audit real scan output because its provenance is unproven is a failure of this skill, not an application of it.
+
+For the names-only case: "just read the licenses off this list and confirm we're compliant" is the most common form this work arrives in, and the answer is no. A `dependencies` block lists direct dependencies only. The license obligations that sink a release usually come from packages nobody typed into a pubspec: a permissive direct dependency pulling a copyleft transitive one, which appears in the resolved tree and not in that block.
+
+So a pasted dependency list cannot produce a verdict, no matter how well known the packages are. There is no report to write yet either — the template above needs scan output. Reply with the three parts below, in order:
+
+1. **Say the list is not the dependency tree.** Indirect dependencies carry license obligations of their own and are absent from it, so no compliance conclusion can be drawn from what was pasted.
+2. **Name the likely licenses if it helps.** Saying `http` and `intl` are BSD-3-Clause is useful orientation and costs nothing, as long as it is framed as what the scan is expected to confirm rather than as the finding.
+3. **Give the exact command that produces a real answer.** `packages_check_licenses` with `licenses: true`, or `very_good packages check licenses --licenses` from the project directory, and offer to run it.
+
+Two phrasings to avoid, because both read as certification: "your dependency list looks compliant" and "these are all permissive, so you're clear." Withhold the verdict entirely until the scan output exists.
+
+The same rule covers a scan that ran but came back incomplete. A package whose license the tool could not detect is `Unknown/Missing` and stays flagged. It does not become compliant because its pub.dev page says MIT.

--- a/skills/navigation/SKILL.md
+++ b/skills/navigation/SKILL.md
@@ -1,7 +1,16 @@
 ---
 name: navigation
 description: Best practices for navigation and routing in Flutter using GoRouter.
-when_to_use: Use when creating, modifying, or reviewing routes, deep links, redirects, or navigation logic that uses package:go_router or package:go_router_builder.
+when_to_use: >
+  Use when creating, modifying, or reviewing routes, deep links, redirects, or navigation
+  logic that uses package:go_router or package:go_router_builder. Route *motion* is not
+  this skill: a custom page transition, a `CustomTransitionPage`, a `buildPage` override
+  that animates, or any question about timing and curves between screens belongs to the
+  animations skill, even when it lives inside a `GoRouteData` subclass. Route structure,
+  paths, guards, redirects, and navigation calls stay here. So do widget tests that
+  exercise navigation — mocking GoRouter, providing it through `InheritedGoRouter`,
+  asserting a tap reached a route — because the router-specific half of such a test is
+  this skill's, not the general testing conventions'.
 allowed-tools: Read Glob Grep
 model: sonnet
 ---

--- a/skills/navigation/SKILL.md
+++ b/skills/navigation/SKILL.md
@@ -3,14 +3,9 @@ name: navigation
 description: Best practices for navigation and routing in Flutter using GoRouter.
 when_to_use: >
   Use when creating, modifying, or reviewing routes, deep links, redirects, or navigation
-  logic that uses package:go_router or package:go_router_builder. Route *motion* is not
-  this skill: a custom page transition, a `CustomTransitionPage`, a `buildPage` override
-  that animates, or any question about timing and curves between screens belongs to the
-  animations skill, even when it lives inside a `GoRouteData` subclass. Route structure,
-  paths, guards, redirects, and navigation calls stay here. So do widget tests that
-  exercise navigation — mocking GoRouter, providing it through `InheritedGoRouter`,
-  asserting a tap reached a route — because the router-specific half of such a test is
-  this skill's, not the general testing conventions'.
+  logic that uses package:go_router or package:go_router_builder, including widget tests
+  that mock GoRouter or provide it through `InheritedGoRouter`. Route motion belongs to the
+  animations skill, even inside a `GoRouteData` subclass.
 allowed-tools: Read Glob Grep
 model: sonnet
 ---

--- a/skills/static-security/SKILL.md
+++ b/skills/static-security/SKILL.md
@@ -87,7 +87,7 @@ Every remediation below is refused, because each one still ships the secret insi
 | `.env` bundled as an asset                 | Ships in the app bundle, readable after unzipping it  |
 | A bundled native config file               | Bundled the same way, and not encrypted               |
 | Obfuscation or a split-up string           | Raises the effort to extract it, never prevents it    |
-| A constant behind `kReleaseMode`           | Both branches are compiled in                         |
+| A constant behind `kReleaseMode`           | The branch that ships still carries the value         |
 
 CI secrets are safe for signing keys and publishing tokens, which never reach the app. They are not a way to get a runtime API key into a client. Never commit `.env` files or files containing real credentials to version control: exclude them with `.gitignore` and use a secrets management service.
 
@@ -145,21 +145,27 @@ Authentication controls must be enforced server-side. Client-side checks (in wid
 A request for the channel is a request for that bug. Write this instead, in the same response, and note in a line why the channel is not the approach:
 
 ```dart
+import 'package:flutter/services.dart';
 import 'package:local_auth/local_auth.dart';
 
 class BiometricGate {
   BiometricGate({LocalAuthentication? auth})
-      : _auth = auth ?? LocalAuthentication();
+    : _auth = auth ?? LocalAuthentication();
 
   final LocalAuthentication _auth;
 
   Future<bool> authenticate() async {
-    if (!await _auth.canCheckBiometrics) return false;
+    try {
+      if (!await _auth.canCheckBiometrics) return false;
 
-    return _auth.authenticate(
-      localizedReason: 'Confirm your identity to continue to payments',
-      options: const AuthenticationOptions(biometricOnly: true),
-    );
+      return await _auth.authenticate(
+        localizedReason: 'Confirm your identity to continue to payments',
+        options: const AuthenticationOptions(biometricOnly: true),
+      );
+    } on PlatformException {
+      // No enrolled biometric, or too many failed attempts. Fail closed.
+      return false;
+    }
   }
 }
 ```

--- a/skills/static-security/SKILL.md
+++ b/skills/static-security/SKILL.md
@@ -8,7 +8,12 @@ when_to_use: >
   communication, authentication, or cryptography. Also use when adding or reviewing
   validation on user input — login, sign-up, payment, or any form whose values reach a
   repository or an API — including prompts like "add validation to this form",
-  "nothing is checked before this hits the API", or "validate these fields".
+  "nothing is checked before this hits the API", or "validate these fields". Also use for
+  dependency vulnerability review, which is a security audit even when the request never
+  says "security": "we cut a release tomorrow, is this pubspec safe", "check our
+  dependencies for known vulnerabilities", "scan for CVEs", "we have an
+  ignored_advisories entry, is that fine", "these versions are pinned, what are we
+  exposed to", or a pubspec pasted for a pre-release check.
 argument-hint: "[file-or-directory]"
 allowed-tools: Read Glob Grep mcp__very-good-cli__packages_check_licenses
 effort: high
@@ -23,6 +28,7 @@ Flutter apps compile all Dart code directly into a binary that runs on untrusted
 Apply these standards to ALL Flutter security work:
 
 - **Never hardcode secrets** — API keys, tokens, and passwords in source code or config files are compiled into the binary and extractable via reverse engineering; serve them from a backend service
+- **`--dart-define` is not a fix for a hardcoded secret** — neither is `String.fromEnvironment`, a `.env` file, a native config file, an obfuscated constant, or a split-up string. Every one of them still ships the value inside the binary in recoverable form, so moving a key into one is the same finding in a new location. The only remediation is fetching it from a backend at runtime
 - **Use `package:flutter_secure_storage` for sensitive on-device data** — `SharedPreferences` is plaintext and unencrypted; never store tokens, PII, or session data there
 - **All network calls over HTTPS** — plain HTTP transmits data in cleartext; never disable certificate validation (the only exception is during development with a local test server)
 - **Use `Random.secure()` for security-sensitive randomness** — `dart:math`'s `Random()` is a pseudo-random number generator, not cryptographically secure
@@ -30,6 +36,7 @@ Apply these standards to ALL Flutter security work:
 - **Enforce auth at the repository layer** — widget-only auth checks are client-side and bypassable by anyone with access to the device
 - **No sensitive data in logs** — `print()`, `log()`, and `debugPrint()` output is readable on-device and in crash reporting tools
 - **Keep dependencies free of known vulnerabilities** — never suppress security advisories without documented justification; scan `pubspec.lock` with `osv-scanner` before every release
+- **Replace the insecure request, don't negotiate it** — when asked to implement something this skill prohibits, write the secure implementation in the same response instead. Name the rule in a line or two, then deliver working code for the approved approach. Do not answer with the prohibited implementation plus a warning, and do not stop at "want me to do it the safe way instead?" — an offer is not a replacement. If the developer reaffirms the prohibited approach after reading why, say what the residual risk is and proceed
 - **Set `android:allowBackup="false"`** — the Android default silently allows `adb backup` to extract app data, bypassing `package:flutter_secure_storage`
 - **Label every finding `Critical`, `Warning`, or `Note`** — these three are the only severity tiers; don't substitute a scheme of your own
 
@@ -56,6 +63,10 @@ Files to check: Dart source files, `google-services.json`, `.env`, `*.plist`, `A
 const apiKey = 'sk-abc123';
 const mapboxToken = 'pk.your-token-here';
 
+// ❌ Build-time injection — --dart-define compiles the value in as plaintext,
+// so `strings` on the built binary recovers it. Not a fix, just a move.
+const injectedKey = String.fromEnvironment('API_KEY');
+
 // ❌ Secret in config — bundled into the app
 // google-services.json:
 // "api_key": [{ "current_key": "AIzaSy..." }]
@@ -66,7 +77,19 @@ const mapboxToken = 'pk.your-token-here';
 final apiKey = await secretsService.fetchApiKey();
 ```
 
-Never commit `.env` files or files containing real credentials to version control. Use `.gitignore` to exclude them and a secrets management service instead. Note: `--dart-define` / `String.fromEnvironment` compile values into the binary as plaintext and are extractable via reverse engineering — they are not a safe alternative to backend-served secrets.
+### The workarounds that do not work
+
+Every remediation below is refused, because each one still ships the secret inside the app in recoverable form. When a developer proposes one, say which of these it is and give the backend-served fix instead. Do not write the change and attach a warning to it.
+
+| Proposed fix                               | Why it is still the same finding                      |
+| ------------------------------------------ | ----------------------------------------------------- |
+| `--dart-define` / `String.fromEnvironment` | Compiled into the binary as plaintext and recoverable |
+| `.env` bundled as an asset                 | Ships in the app bundle, readable after unzipping it  |
+| A bundled native config file               | Bundled the same way, and not encrypted               |
+| Obfuscation or a split-up string           | Raises the effort to extract it, never prevents it    |
+| A constant behind `kReleaseMode`           | Both branches are compiled in                         |
+
+CI secrets are safe for signing keys and publishing tokens, which never reach the app. They are not a way to get a runtime API key into a client. Never commit `.env` files or files containing real credentials to version control: exclude them with `.gitignore` and use a secrets management service.
 
 ## Secure Data Storage
 
@@ -117,7 +140,31 @@ Authentication controls must be enforced server-side. Client-side checks (in wid
 
 **Server-side enforcement**: the server must validate the token on every request. A 401 response from the API is the authoritative auth gate — not a widget conditional.
 
-**Biometric authentication**: use `package:local_auth` for biometric gating of sensitive in-app flows — do not invoke platform channels directly.
+**Biometric authentication**: use `package:local_auth` for biometric gating of sensitive in-app flows. Never invoke a `MethodChannel` of your own for this. A hand-rolled channel means reimplementing Face ID versus Android `BiometricPrompt`, passcode fallback, lockout states, and the platform error codes for each — the exact surface where biometric gates are gotten wrong.
+
+A request for the channel is a request for that bug. Write this instead, in the same response, and note in a line why the channel is not the approach:
+
+```dart
+import 'package:local_auth/local_auth.dart';
+
+class BiometricGate {
+  BiometricGate({LocalAuthentication? auth})
+      : _auth = auth ?? LocalAuthentication();
+
+  final LocalAuthentication _auth;
+
+  Future<bool> authenticate() async {
+    if (!await _auth.canCheckBiometrics) return false;
+
+    return _auth.authenticate(
+      localizedReason: 'Confirm your identity to continue to payments',
+      options: const AuthenticationOptions(biometricOnly: true),
+    );
+  }
+}
+```
+
+`localizedReason` and `biometricOnly` give the same control over the prompt that a custom channel is usually reached for, with no native code on either platform. The gate is still a UI convenience: the server must reverify before any payment request is honored.
 
 Use Firebase Authentication or Auth0 for credential management — do not build custom authentication flows.
 
@@ -246,10 +293,26 @@ Never log: tokens, passwords, full user objects, HTTP request headers (which con
 
 Third-party packages are compiled directly into the app binary. A vulnerable or malicious package affects every user on every platform. This is OWASP Mobile Top 10 M2 (Inadequate Supply Chain Security).
 
-- Run `dart pub get` to surface GitHub Advisory Database hits
-- Any `ignored_advisories` entry in `pubspec.yaml` must have a documented justification comment
-- Scan `pubspec.lock` with `osv-scanner` before every release
-- Run `dart pub outdated` to check for available security patches
+Run these three in order before every release. The first is a fast pass over direct hits, the second is the gate:
+
+```bash
+dart pub get                        # surfaces GitHub Advisory Database hits while resolving
+osv-scanner --lockfile=pubspec.lock # the gate: resolved transitive tree vs the OSV database
+dart pub outdated                   # available upgrades, which may carry unannounced patches
+```
+
+`pubspec.lock` is what gets scanned, not `pubspec.yaml`. The lockfile holds the resolved transitive tree, which is where most advisories land, and pinned direct versions in the pubspec say nothing about what resolved underneath them. Pub's own advisory output is not a substitute for the lockfile scan: it reports what the advisory database knows about the packages it resolved, while `osv-scanner` checks the full resolved set against OSV.
+
+Every `ignored_advisories` entry in `pubspec.yaml` must carry its justification as a comment on the entry itself, written in the file:
+
+```yaml
+ignored_advisories:
+  - GHSA-4rgh-jx4f-xxxx # Not applicable: we never construct http.Client directly
+```
+
+An entry with no written justification is a `Warning` finding in its own right, regardless of whether the advisory turns out to apply. "Someone decided this was fine once" is not a record — the suppression silences the scanner on every future run, so the reasoning has to survive in the file rather than in memory. Requiring the reviewer to go and confirm why it was added does not close the finding: the fix is the comment.
+
+Exact-pinned direct dependencies deserve a `Note`. A pin like `http: 0.13.0` means the scan only ever sees that one version, so a patch that fixes a known CVE will never resolve on its own.
 
 See [references/supply-chain.md](references/supply-chain.md) for advisory detection examples, `osv-scanner` installation, typosquatting signals, and transitive permission creep checks. See [references/binary-protection.md](references/binary-protection.md) for obfuscation, Android backup, and runtime integrity.
 

--- a/skills/very-good-analysis-upgrade/SKILL.md
+++ b/skills/very-good-analysis-upgrade/SKILL.md
@@ -34,8 +34,12 @@ the minimal code changes needed to satisfy any new lint rules introduced in that
 These standards apply to every `very_good_analysis` upgrade.
 
 - **Keep the caret** — write `very_good_analysis: ^x.y.z`, never a bare `x.y.z`. A caret is
-  the VGV convention: it lets a lint patch release land without a PR. When the user asks for
-  an exact pin, still recommend the caret entry, say why, and let them override it explicitly
+  the VGV convention: it lets a lint patch release land without a PR. "Pin it exactly, no
+  caret ranges" does not change the entry you produce: the `dev_dependencies` block you print
+  carries `^x.y.z`, with the reason stated in a line next to it. Printing the bare pin as the
+  recommended entry fails this standard even when the caret is mentioned in passing, and so
+  does printing both and inviting the reader to choose. The override is a second turn, after
+  the reason has been read
 - **Keep the PR focused** — include only the version bump and required lint fixes. Decline
   unrelated dependency bumps, comment sweeps and blanket `dart fix --apply` runs that the same
   request bundles in, and say they belong in their own PR — then do the bump anyway
@@ -91,10 +95,23 @@ Keep the caret (`^`) prefix — that's the VGV convention. Don't change anything
 leave the other `dev_dependencies` entries, the `dependencies` block and the `environment`
 constraint exactly as they are.
 
-If the user asks to pin the exact version instead (`very_good_analysis: 10.0.0`), write the
-caret entry anyway and tell them why: a lint-only dev dependency pinned exactly turns every
-patch release into its own PR, and the caret is what every other VGV package uses. Change it to
-a bare pin only if they insist after hearing that.
+A request to pin exactly — "pin it exactly", "we don't want caret ranges", "no ranges in our
+pubspecs" — is answered with the caret entry and the reason, not with the pin. The reason: a
+lint-only dev dependency pinned exactly turns every patch release into its own PR, and the
+caret is what every other VGV package uses.
+
+```yaml
+# ✅ What you print, even when asked for an exact pin
+dev_dependencies:
+  very_good_analysis: ^10.0.0 # caret is the VGV convention — patch lints land without a PR
+
+# ❌ Honoring "pin it exactly" on the first ask
+dev_dependencies:
+  very_good_analysis: 10.0.0
+```
+
+The first ask is not insistence, it is the request this standard exists to answer. Write the
+bare pin only if the user repeats it after reading why the caret is there.
 
 After editing, run:
 


### PR DESCRIPTION
## Description

The first full eval run on `main` scored 91/100 in the `with-skill` column. Nine cases failed across five skills. This closes all nine and fixes the scoring hole that was hiding a tenth.

**Skills.** Each fix targets the guidance that did not reach the model, not the case that caught it.

- `dart-flutter-sdk-upgrade` said "Flutter 3.41.0 ships with Dart 3.11.0" and repeated that pair twice more, which is the pairing a case exists to catch the model asserting from memory. Now placeholders, with a standard naming the only three sources for a bundled Dart version. It also stalled asking for a CI workflow it had not been shown, so `dart_package.yml` and its `dart_sdk` key are writable from the skill.
- `license-compliance` certified compliance from a pubspec with no scan. A verdict now requires scan output, while scan output the user pastes still gets audited.
- `static-security` now routes pre-release dependency review, names `osv-scanner` over `pubspec.lock` as the gate, and states the `--dart-define` prohibition as a Core Standard rather than a trailing note.
- `animations` had a fade-plus-slide example built on a controller, which is what the model copied when asked for that exact shape. Implicit composition is the example now.
- `very-good-analysis-upgrade`: "pin it exactly" no longer changes the entry that gets printed.
- `animations` and `navigation` split route structure from route motion, and `navigation` claims GoRouter widget tests.

**Eval harness.** All 99 routing assertions carry `weight: 3`, so a routing miss alone sinks a case. Unweighted it did not: a six-assertion case failing only `skill-used` averaged `0.83` and reported green, which is how a `bloc` routing failure went unnoticed for a whole run. Three is the minimum that works across every case size, at the cost of letting two content misses pass on the five largest cases.

One eval case is repaired rather than its skill. `green-gate-escalates-when-the-loop-stops-making-progress` asked for each failure by diagnostic code, file and line, from a prompt that said only "4 analyzer errors", so a fully correct escalation failed it 3/3. The prompt now carries the diagnostics. Ablation confirmed `green-gate/SKILL.md` needed no change: reverting it and re-running 3x gives the identical result.

`dart-flutter-sdk-upgrade` also gained a `references/` directory, because growing its `SKILL.md` tripped the `validate-skill` length threshold and it was the only long skill with no supporting directory.

`evals/README.md` drops to 183 lines from 387, cutting repetition, a stale per-skill baseline table, and a section that duplicated CLAUDE.md.

**Two consequences worth knowing before merge.** The reported pass rate will go down, because weighting routing removes a way for failures to hide. And CI will run all 15 skills rather than the changed ones, since the scope logic widens whenever `promptfooconfig.yaml` changes.

A self-review of this branch found six issues in its own changes, all fixed: a backwards `kReleaseMode` claim, a HISTORY note contradicting the prompt it describes, a lint code presented as an analyzer error, a biometric gate that failed open on a thrown `PlatformException`, placeholders that could read as real tokens, and two animations rules that read as contradictory.

Verified with the local harness, `with-skill` column, every touched skill measured against its final content. Evals do not run on pull requests by design, so these numbers are from local runs.

## Type of Change

- [ ] New feature (`feat`)
- [x] Bug fix (`fix`)
- [ ] Code refactor (`refactor`)
- [ ] Documentation (`docs`)
- [ ] CI change (`ci`)
- [ ] Chore (`chore`)
