### PR TITLE
feat: document the skills.sh install path and guard it in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -73,6 +73,42 @@ jobs:
           echo "Valid: ${{ steps.validate.outputs.valid }}"
           echo "Errors: ${{ steps.validate.outputs.errors }}"
           echo "Warnings: ${{ steps.validate.outputs.warnings }}"
+  skills-install:
+    name: 📥 Skills Install
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version: '22'
+      - name: Install this tree with the skills CLI
+        env:
+          DISABLE_TELEMETRY: '1'
+          DO_NOT_TRACK: '1'
+        run: |
+          mkdir -p "$RUNNER_TEMP/skills-install"
+          cd "$RUNNER_TEMP/skills-install"
+          npx --yes skills@latest add "$GITHUB_WORKSPACE" --all
+      - name: Verify every skill installed into .agents/skills
+        run: |
+          target="$RUNNER_TEMP/skills-install/.agents/skills"
+          expected=$(find -L skills -name SKILL.md -type f | \
+            xargs -n1 dirname | xargs -n1 basename | sort -u)
+          actual=$(ls -1 "$target" | sort -u)
+          if [ "$expected" != "$actual" ]; then
+            echo "::error::skills CLI discovery does not match skills/ in this tree."
+            echo "A skill the CLI cannot see is a skill nobody can install with npx skills."
+            diff <(echo "$expected") <(echo "$actual") || true
+            exit 1
+          fi
+          for skill in $expected; do
+            if ! diff -r "skills/$skill" "$target/$skill" >/dev/null; then
+              echo "::error::$skill was rewritten on install and no longer matches the source."
+              diff -r "skills/$skill" "$target/$skill" || true
+              exit 1
+            fi
+          done
+          echo "$(echo "$expected" | wc -l) skills installed byte-identical into .agents/skills/"
   plugin-validate:
     name: 📦 Plugin Validation
     runs-on: ubuntu-latest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -194,6 +194,20 @@ Isolation between the two columns is held by the provider keys in `promptfooconf
 and nothing checks it automatically, so treat any change to `tools`, `working_dir`,
 `setting_sources` or `plugins` as invalidating earlier numbers.
 
+## Publishing
+
+Two install paths ship from this repo. The Claude Code plugin carries everything: skills,
+hooks, the `flutter-reviewer` agent, and the MCP servers. The
+[skills.sh](https://skills.sh) registry carries the skills alone, installed with
+`npx skills add VeryGoodOpenSource/vgv-ai-flutter-plugin` into `.agents/skills/` on any
+host that reads it.
+
+The registry needs no manifest and no submission, but it does depend on the `skills` CLI
+finding every skill at `skills/<name>/SKILL.md`. Adding a `SKILL.md` at the repository
+root shadows that whole tree. The `Skills Install` CI job guards the contract. See
+`CONTRIBUTING.md` → Cross-harness portability → Publishing to skills.sh, which is the
+authority on it.
+
 ## Commits
 
 Use conventional commits: `type(scope): description`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -203,6 +203,29 @@ it **user-invoked**: set `disable-model-invocation: true` in the frontmatter and
 `policy.allow_implicit_invocation: false` in its `agents/openai.yaml`, and keep the two in
 sync — a skill is user-invoked in both harnesses or neither.
 
+**Publishing to skills.sh** — this repo is published to the
+[skills.sh](https://skills.sh) registry, so `npx skills add
+VeryGoodOpenSource/vgv-ai-flutter-plugin` installs every skill here into `.agents/skills/`
+on any host that reads it. There is nothing to submit and no registry manifest to maintain:
+the `skills` CLI clones the repo and walks it, and the listing populates itself from
+anonymous install telemetry. What the listing depends on is **discovery**, and discovery
+is a contract on the tree's shape:
+
+- Skills stay at `skills/<name>/SKILL.md`. That is one of the CLI's standard search
+  locations, which is why no `skills` array in `.claude-plugin/plugin.json` is needed. The
+  CLI does read a `skills` array when a plugin manifest declares one, but only to reach
+  paths outside its bounded depth-3 walk, and every skill here is already inside it.
+- **Never add a `SKILL.md` at the repository root.** A root skill shadows the whole
+  `skills/` tree, and the CLI then discovers exactly one skill instead of all of them.
+  `validate-skill` would still pass, so nothing else would catch it.
+- A skill the CLI cannot read is dropped in silence, not reported. Malformed frontmatter
+  is the usual cause, which is what the frontmatter rules above are protecting.
+
+The `Skills Install` CI job holds this contract: it installs the pull request's own tree
+with the CLI and fails if the set of installed skills differs from `skills/`, or if any
+installed skill is no longer byte-identical to its source. It sets `DISABLE_TELEMETRY=1`,
+so CI runs never inflate the registry's install counts.
+
 ## Testing Locally
 
 Editing a skill or hook and pushing straight to a PR only tells you the files
@@ -276,6 +299,20 @@ Then, inside a session:
 /plugin install vgv-ai-flutter-plugin
 ```
 
+### Rehearse the skills.sh install (optional)
+
+The `skills` CLI takes a local path as a source, so you can install your working copy
+exactly the way a user on another host would, without pushing:
+
+```bash
+mkdir /tmp/skills-test && cd /tmp/skills-test
+DISABLE_TELEMETRY=1 npx --yes skills@latest add /ABSOLUTE/path/to/vgv-ai-flutter-plugin --all
+```
+
+Skills land in `/tmp/skills-test/.agents/skills/`, with per-agent directories linking to
+them. Check that the skill you touched is present and that its `references/` came with it.
+Keep `DISABLE_TELEMETRY=1` set so a local rehearsal is not counted as a real install.
+
 ### Validate before you push
 
 Run the same check CI runs, from the repository root:
@@ -307,6 +344,7 @@ Every pull request runs the following checks automatically:
 | Markdown quality | Lints all `*.md` files with markdownlint-cli2 | `config/custom.markdownlint.jsonc` |
 | Spelling | Runs cspell on all `*.md` files | `config/cspell.json` |
 | Skill validation | Validates **every** `SKILL.md`'s frontmatter and structure against the Agent Skills spec, so a malformed skill fails the build instead of silently vanishing on another host | `Flash-Brew-Digital/validate-skill@v1` |
+| Skills install | Installs this tree with the `skills` CLI and checks every skill lands in `.agents/skills/` byte-identical, so the `npx skills add` path cannot regress unnoticed | `.github/workflows/ci.yaml` |
 | Plugin validation | Validates and test-installs the plugin | `claude plugin validate .` |
 | Script tests | Runs the hook scripts' own test suites | `hooks/scripts/*_test.sh` |
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ VGV AI Flutter Plugin is a collection of contextual best-practices skills that C
 
 ## Installation
 
+### Claude Code
+
 One-line install from your terminal:
 
 ```bash
@@ -34,6 +36,18 @@ Or inside an active Claude Code session, run these as **two separate commands** 
    ```
 
 For more details, see the [Very Good Claude Marketplace][marketplace_link].
+
+### Other agents
+
+The skills are also published to the [skills.sh][skills_sh_link] registry as [Agent Skills][agentskills_link], so any agent that reads `.agents/skills/` can install them:
+
+```bash
+npx skills add VeryGoodOpenSource/vgv-ai-flutter-plugin
+```
+
+That command installs every skill in this repository into `.agents/skills/`, byte-identical to the copies here, and wires them into each agent's own skills directory. Loading is verified on Claude Code, Codex, and Gemini CLI. The `skills` CLI also wires up Amp, Cursor, GitHub Copilot, and OpenCode, which this repository does not test.
+
+Skills are all this path installs. The hooks, the `flutter-reviewer` agent, and the two MCP servers are Claude Code plugin features and still need the plugin install above. Every skill that drives an MCP tool names the equivalent `very_good`, `dart`, or `flutter` command as a fallback, so none of them blocks when the servers are absent.
 
 ## Skills
 
@@ -188,6 +202,8 @@ The Very Good CLI MCP server exposes Very Good CLI commands to Claude.
 The `.mcp.json` file at the project root registers the `dart` and `very-good-cli` MCP servers using stdio transport. When Claude Code detects this configuration, it connects to both servers and gains access to the tools above. The skills continue to provide knowledge and best practices while the MCP tools handle execution.
 
 [marketplace_link]: https://github.com/VeryGoodOpenSource/very-good-claude-code-marketplace
+[skills_sh_link]: https://skills.sh/?q=vgv-ai-flutter-plugin
+[agentskills_link]: https://agentskills.io/specification
 [claude_code_link]: https://claude.ai/code
 [vgv_link]: https://verygood.ventures
 [very_good_ventures_link_dark]: https://verygood.ventures#gh-dark-mode-only


### PR DESCRIPTION
## Description

Closes #50. Phase 1 of #51.

**The listing needed no release work.** skills.sh has no submission step and no registry manifest. The `skills` CLI clones the repo, walks it, and the listing populates itself from anonymous install telemetry. `skills/` is already one of the CLI's standard search locations, so all 15 skills are discovered with no restructure and no `skills` array in `.claude-plugin/plugin.json`. The issue's note that a restructure would be unnecessary still holds.

The repo is listed today, under its current name, with all 15 skills. Verified against the registry API rather than the leaderboard UI.

### Verified

- `npx skills add VeryGoodOpenSource/vgv-ai-flutter-plugin` installs all 15 skills into `.agents/skills/`, **byte-identical** to the copies here, `references/` subtrees and `agents/openai.yaml` sidecars included. `.claude/skills/` symlinks into it.
- They **load**: all 15 appear in Claude Code, Codex, and Gemini CLI in the installed project. In Claude Code they list unprefixed, alongside the plugin's own `vgv-ai-flutter-plugin:*` set, which shows the two install paths are independent.
- Phase 0 prerequisites hold in the tree, checked rather than assumed: no `when_to_use` in any skill, every `description` between 50 and 1024 characters (longest is `green-gate` at 946), no cross-skill `../other-skill/…` paths, no symlinks under `skills/`, `$ARGUMENTS` and `AskUserQuestion` fallbacks present where used, and every MCP-driving skill names its CLI fallback.

Every verification run set `DISABLE_TELEMETRY=1`, so none of them touched the registry's install counts.

### Changes

- **README.md** — an `Other agents` install section under `Installation`, with the existing marketplace steps moved under `Claude Code`. It claims only the three harnesses tested, and names the four the CLI also wires that this repo does not test. It also says plainly that skills are all this path installs, since hooks, the subagent, and the MCP servers stay Claude Code plugin features.
- **CONTRIBUTING.md** — the publishing contract in `Cross-harness portability`, plus a local rehearsal of the install. The load-bearing rule: **never add a `SKILL.md` at the repository root**. A root skill shadows the whole `skills/` tree and the CLI then finds exactly one skill, while `validate-skill` still passes.
- **.github/workflows/ci.yaml** — a `Skills Install` job that installs the pull request's own tree with the CLI and fails if the discovered set drifts from `skills/`, or if any installed skill stops matching its source. Telemetry suppressed.
- **AGENTS.md** — a short `Publishing` section pointing at CONTRIBUTING as the authority.

The CI job's failure paths were tested, not just its success path: a missing skill, stripped frontmatter, and a dropped reference file each exit 1. The install was also rehearsed under `env -i` with no agent environment, to match a bare runner.

`config/cspell.json` is unchanged because the new prose introduced no words cspell flags.

### Not done

Eleven stale `vgv-`prefixed duplicate entries sit on the registry next to the 15 real ones, left over from an earlier naming. They carry lower install counts than the live entries. Nothing in this repo produces them and nothing here can remove them, so pruning would have to go through skills.sh.

## Type of Change

- [x] New feature (`feat`)
- [ ] Bug fix (`fix`)
- [ ] Code refactor (`refactor`)
- [ ] Documentation (`docs`)
- [ ] CI change (`ci`)
- [ ] Chore (`chore`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
