### PR TITLE
chore: update contact email to tools@verygood.ventures

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -8,7 +8,7 @@
   "author": {
     "name": "Very Good Ventures",
     "url": "https://verygood.ventures",
-    "email": "hello@verygood.ventures"
+    "email": "tools@verygood.ventures"
   },
   "keywords": [
     "a11y",

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -55,7 +55,7 @@ further defined and clarified by project maintainers.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting the project team at <hello@verygood.ventures>. All
+reported by contacting the project team at <tools@verygood.ventures>. All
 complaints will be reviewed and investigated and will result in a response that
 is deemed necessary and appropriate to the circumstances. The project team is
 obligated to maintain confidentiality with regard to the reporter of an incident.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -16,7 +16,7 @@ Report vulnerabilities through [GitHub's private vulnerability reporting](https:
 
 ### Email
 
-Send an email to `hello@verygood.ventures` with a `[SECURITY]` subject prefix.
+Send an email to `tools@verygood.ventures` with a `[SECURITY]` subject prefix.
 
 ### What to Include
 


### PR DESCRIPTION
Moves `hello@verygood.ventures` to `tools@verygood.ventures` across the repo:

- `.claude-plugin/plugin.json` — the `author.email` field. Aligns with the same change already made to `.codex-plugin/plugin.json` on #151, so the two manifests agree.
- `CODE_OF_CONDUCT.md` — the conduct-report contact.
- `SECURITY.md` — the vulnerability-disclosure contact.

Three one-line edits, no other changes. The manifest edit was applied as targeted text rather than through a JSON library, so the file is not reflowed and the em dash in `description` is preserved. Both markdown files keep their existing markup (autolink in one, code span in the other).

Nothing generates or validates any of these values, so there is no test to add.

Verified: `jq` parses the manifest, `claude plugin validate .` exits 0 (with the pre-existing CLAUDE.md-at-plugin-root warning), and cspell and markdownlint are both clean across all 70 markdown files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)